### PR TITLE
feature: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,71 @@
+name: Bug
+description: Report a bug
+body:
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Confirm the following items before proceeding. If one cannot be satisfied, create a discussion thread instead.
+      options:
+        - label: I've read the [contribution guidelines](https://tier4.github.io/AWSIM/DeveloperGuide/HowToContribute/).
+          required: true
+        - label: I've searched other [issues](https://github.com/tier4/AWSIM/issues?q=is%3Aissue) and [discussions Q&A category](https://github.com/orgs/autowarefoundation/discussions/categories/q-a). I found no duplicate issues.
+          required: true
+        - label: I'm convinced that this is not my fault but a bug.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Write a brief description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: Describe the expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual behavior
+      description: Describe the actual behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Write the steps to reproduce the bug.
+      placeholder: |-
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Versions
+      description: Provide the version information. You can omit this if you believe it's irrelevant.
+      placeholder: |-
+        - OS:
+        - ROS 2:
+        - Autoware:
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Possible causes
+      description: Write the possible causes if you have any ideas.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other additional context if it exists.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://github.com/autowarefoundation/autoware/discussions/new?category=q-a
+    about: Ask a question

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,19 @@
+name: Feature request
+description: request a feature
+body:
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Confirm the following items before proceeding.
+      options:
+        - label: I've read the [contribution guidelines](https://tier4.github.io/AWSIM/DeveloperGuide/HowToContribute/).
+          required: true
+        - label: I've searched other issues and no duplicate issues were found.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Write a brief description of the task.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -1,0 +1,40 @@
+name: Task
+description: Plan a task
+body:
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Confirm the following items before proceeding.
+      options:
+        - label: I've read the [contribution guidelines](https://tier4.github.io/AWSIM/DeveloperGuide/HowToContribute/).
+          required: true
+        - label: I've searched other issues and no duplicate issues were found.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Write a brief description of the task.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Purpose
+      description: Describe the purpose of the task.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Possible approaches
+      description: Describe possible approaches for the task.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Definition of done
+      description: Write the definition of done for the task.
+    validations:
+      required: true


### PR DESCRIPTION
Signed-off-by: Shumpei Wakabayashi <shumpei.wakabayashi@tier4.jp>

I add issue template to 
- clarify what the issue is
- support what information should be written
- share the knowledge with AWF

Issues in AWSIM will be only for 
- bug reports  
- feature request
- task 

while the question will be discussed in [AWF discussion](https://github.com/orgs/autowarefoundation/discussions/).
The picture shows the image when you try to create the Issue.
You can try this with [my prototype](https://github.com/shmpwk/AWSIM/issues/new/choose).
![image](https://user-images.githubusercontent.com/42209144/215381972-f5f445de-03b0-41c0-9882-bc108c3d7af7.png)

Note that this PR partially comes from https://github.com/autowarefoundation/autoware/commit/9581b82ac8a91877e6ed2a00253d3f122fb39270

I will add contribution guidline to describe how to use them https://github.com/tier4/AWSIM/pull/83. 