### PR TITLE
docs: apply navigation.footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ theme:
     primary: indigo
   features:
     - navigation.sections
+    - navigation.footer
     - content.tabs.link
   icon:
     repo: fontawesome/brands/github
@@ -18,7 +19,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.details
   - pymdownx.tabbed:
-      alternate_style: true 
+      alternate_style: true
   - attr_list
 
 nav:


### PR DESCRIPTION
The footer navigation is gone.
![mkdocs_footter](https://user-images.githubusercontent.com/16977736/215702461-251cd86f-29b3-41fa-bea2-bac8b7114a0c.png)


The major version of mkdocs material has been upgraded and a new configuration item has been added.
https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#navigation

This PR will enable the above settings and behave the same as before

