### PR TITLE
Random traffic slightly improve

### DIFF
--- a/Assets/AWSIM/Scenes/Main/AutowareSimulation.unity
+++ b/Assets/AWSIM/Scenes/Main/AutowareSimulation.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 1537.1846, g: 1904.3379, b: 2519.752, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -930,7 +930,7 @@ PrefabInstance:
       objectReference: {fileID: 7808269042169720464}
     - target: {fileID: 9027057600357292012, guid: 58d73df60b244d146bdf5f5896f78355, type: 3}
       propertyPath: cullingDistance
-      value: 150
+      value: 3000
       objectReference: {fileID: 0}
     - target: {fileID: 9027057600357292012, guid: 58d73df60b244d146bdf5f5896f78355, type: 3}
       propertyPath: maxVehicleCount
@@ -971,6 +971,10 @@ PrefabInstance:
     - target: {fileID: 9027057600357292012, guid: 58d73df60b244d146bdf5f5896f78355, type: 3}
       propertyPath: spawnableLanes.Array.size
       value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 9027057600357292012, guid: 58d73df60b244d146bdf5f5896f78355, type: 3}
+      propertyPath: vehicleConfig.Acceleration
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 9027057600357292012, guid: 58d73df60b244d146bdf5f5896f78355, type: 3}
       propertyPath: spawnableLanes.Array.data[0]
@@ -1072,6 +1076,10 @@ PrefabInstance:
       propertyPath: spawnableLanes.Array.data[25]
       value: 
       objectReference: {fileID: 1494823432}
+    - target: {fileID: 9027057600357292012, guid: 58d73df60b244d146bdf5f5896f78355, type: 3}
+      propertyPath: vehicleConfig.AbsoluteDeceleration
+      value: 20
+      objectReference: {fileID: 0}
     - target: {fileID: 9027057600357292013, guid: 58d73df60b244d146bdf5f5896f78355, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -2301,6 +2309,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 7808269042169720464}
   Distance: 5.48
+  Offset: 0
   Height: 2.82
   HeightMultiplier: 0.5
 --- !u!114 &2122627084
@@ -2315,6 +2324,53 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 23c1ce4fb46143f46bc5cb5224c934f6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_Version: 7
+  m_ObsoleteRenderingPath: 0
+  m_ObsoleteFrameSettings:
+    overrides: 0
+    enableShadow: 0
+    enableContactShadows: 0
+    enableShadowMask: 0
+    enableSSR: 0
+    enableSSAO: 0
+    enableSubsurfaceScattering: 0
+    enableTransmission: 0
+    enableAtmosphericScattering: 0
+    enableVolumetrics: 0
+    enableReprojectionForVolumetrics: 0
+    enableLightLayers: 0
+    enableExposureControl: 1
+    diffuseGlobalDimmer: 0
+    specularGlobalDimmer: 0
+    shaderLitMode: 0
+    enableDepthPrepassWithDeferredRendering: 0
+    enableTransparentPrepass: 0
+    enableMotionVectors: 0
+    enableObjectMotionVectors: 0
+    enableDecals: 0
+    enableRoughRefraction: 0
+    enableTransparentPostpass: 0
+    enableDistortion: 0
+    enablePostprocess: 0
+    enableOpaqueObjects: 0
+    enableTransparentObjects: 0
+    enableRealtimePlanarReflection: 0
+    enableMSAA: 0
+    enableAsyncCompute: 0
+    runLightListAsync: 0
+    runSSRAsync: 0
+    runSSAOAsync: 0
+    runContactShadowsAsync: 0
+    runVolumeVoxelizationAsync: 0
+    lightLoopSettings:
+      overrides: 0
+      enableDeferredTileAndCluster: 0
+      enableComputeLightEvaluation: 0
+      enableComputeLightVariants: 0
+      enableComputeMaterialVariants: 0
+      enableFptlForForwardOpaque: 0
+      enableBigTilePrepass: 0
+      isFptlEnabled: 0
   clearColorMode: 0
   backgroundColorHDR: {r: 0.025, g: 0.07, b: 0.19, a: 0}
   clearDepth: 1
@@ -2370,53 +2426,6 @@ MonoBehaviour:
       data1: 0
       data2: 0
   defaultFrameSettings: 0
-  m_Version: 7
-  m_ObsoleteRenderingPath: 0
-  m_ObsoleteFrameSettings:
-    overrides: 0
-    enableShadow: 0
-    enableContactShadows: 0
-    enableShadowMask: 0
-    enableSSR: 0
-    enableSSAO: 0
-    enableSubsurfaceScattering: 0
-    enableTransmission: 0
-    enableAtmosphericScattering: 0
-    enableVolumetrics: 0
-    enableReprojectionForVolumetrics: 0
-    enableLightLayers: 0
-    enableExposureControl: 1
-    diffuseGlobalDimmer: 0
-    specularGlobalDimmer: 0
-    shaderLitMode: 0
-    enableDepthPrepassWithDeferredRendering: 0
-    enableTransparentPrepass: 0
-    enableMotionVectors: 0
-    enableObjectMotionVectors: 0
-    enableDecals: 0
-    enableRoughRefraction: 0
-    enableTransparentPostpass: 0
-    enableDistortion: 0
-    enablePostprocess: 0
-    enableOpaqueObjects: 0
-    enableTransparentObjects: 0
-    enableRealtimePlanarReflection: 0
-    enableMSAA: 0
-    enableAsyncCompute: 0
-    runLightListAsync: 0
-    runSSRAsync: 0
-    runSSAOAsync: 0
-    runContactShadowsAsync: 0
-    runVolumeVoxelizationAsync: 0
-    lightLoopSettings:
-      overrides: 0
-      enableDeferredTileAndCluster: 0
-      enableComputeLightEvaluation: 0
-      enableComputeLightVariants: 0
-      enableComputeMaterialVariants: 0
-      enableFptlForForwardOpaque: 0
-      enableBigTilePrepass: 0
-      isFptlEnabled: 0
 --- !u!81 &2122627085
 AudioListener:
   m_ObjectHideFlags: 0

--- a/Assets/AWSIM/Scripts/NPCs/Vehicles/NPCVehicle.cs
+++ b/Assets/AWSIM/Scripts/NPCs/Vehicles/NPCVehicle.cs
@@ -150,6 +150,11 @@ namespace AWSIM
         /// </summary>
         public Bounds Bounds => bounds;
 
+        /// <summary>
+        /// Vehicle ID.
+        /// </summary>
+        public uint VehicleID { get; set; }
+
         // dynamics settings const values.
         const float maxSteerAngle = 40f;                    // deg
         const float maxSteerSpeed = 60f;                    // deg/s
@@ -406,7 +411,7 @@ namespace AWSIM
             // Cache Gizmos default values.
             var cacheColor = Gizmos.color;
             var cacheMatrix = Gizmos.matrix;
-            
+
             // Apply color and matrix.
             Gizmos.color = Color.white;
             Gizmos.matrix = Matrix4x4.TRS(transform.position, transform.rotation, transform.lossyScale);

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleConfig.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleConfig.cs
@@ -25,13 +25,15 @@ namespace AWSIM.RandomTraffic
         public float Acceleration;
         public float Deceleration;
         public float SuddenDeceleration;
+        public float AbsoluteDeceleration;
 
         public static NPCVehicleConfig Default()
             => new NPCVehicleConfig
             {
                 Acceleration = 3f,
                 Deceleration = 2f,
-                SuddenDeceleration = 4f
+                SuddenDeceleration = 4f,
+                AbsoluteDeceleration = 20f
             };
     }
 }

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
@@ -17,7 +17,8 @@ namespace AWSIM.RandomTraffic
     {
         NONE,
         ENTERING_YIELDING_LANE,
-        YIELDING
+        YIELDING,
+        ON_YELDING_LANE
     }
 
     /// <summary>
@@ -28,6 +29,7 @@ namespace AWSIM.RandomTraffic
         // Immutable states
         public NPCVehicle Vehicle { get; private set; }
         public Vector3 FrontCenterLocalPosition { get; private set; }
+        public Vector3 BackCenterLocalPosition { get; private set; }
 
         // Output from Cognition (Waypoint Following)
         public IList<TrafficLane> FollowingLanes { get; set; } = new List<TrafficLane>();
@@ -70,6 +72,9 @@ namespace AWSIM.RandomTraffic
 
         public Vector3 FrontCenterPosition =>
             Position + Quaternion.AngleAxis(Yaw, Vector3.up) * FrontCenterLocalPosition;
+
+        public Vector3 BackCenterPosition =>
+            Position + Quaternion.AngleAxis(Yaw, Vector3.up) * BackCenterLocalPosition;
 
         public float DistanceToTargetPoint
             => SignedDistanceToPointOnLane(TargetPoint);
@@ -154,6 +159,12 @@ namespace AWSIM.RandomTraffic
                     x = 0f,
                     y = 0f,
                     z = vehicle.Bounds.max.z
+                },
+                BackCenterLocalPosition = new Vector3
+                {
+                    x = 0f,
+                    y = 0f,
+                    z = vehicle.Bounds.min.z
                 }
             };
             state.FollowingLanes.Add(lane);

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
@@ -9,7 +9,8 @@ namespace AWSIM.RandomTraffic
         NORMAL,
         SLOW,
         STOP,
-        SUDDEN_STOP
+        SUDDEN_STOP,
+        ABSOLUTE_STOP
     }
 
     public enum NPCVehicleYieldPhase

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleSpawner.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleSpawner.cs
@@ -83,13 +83,14 @@ namespace AWSIM.RandomTraffic
         /// <param name="prefab">NPC vehicle prefab</param>
         /// <param name="npcVehicleSpawnPoint">Spawn point</param>
         /// <returns>Spawned NPC vehicle.</returns>
-        public NPCVehicle Spawn(GameObject prefab, NPCVehicleSpawnPoint npcVehicleSpawnPoint)
+        public NPCVehicle Spawn(GameObject prefab, uint vehicleID, NPCVehicleSpawnPoint npcVehicleSpawnPoint)
         {
             var obj = Object.Instantiate(prefab, npcVehicleSpawnPoint.Position, Quaternion.identity);
+            obj.name = obj.name + "_" + vehicleID.ToString();
             obj.transform.forward = npcVehicleSpawnPoint.Forward;
             obj.transform.parent = NPCVehicleParentsObj.transform;
             var vehicle = obj.GetComponent<NPCVehicle>();
-
+            vehicle.VehicleID = vehicleID;
             return vehicle;
         }
 

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleCognitionStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleCognitionStep.cs
@@ -307,6 +307,7 @@ namespace AWSIM.RandomTraffic
                                     state.YieldPhase = NPCVehicleYieldPhase.ENTERING_YIELDING_LANE;
                                     state.YieldPoint = GetStopPoint(nextLane);
                                     state.YieldLane = nextLane;
+                                    break;
                                 }
                             }
                             // Check if the current lane is a yielding lane.
@@ -318,6 +319,7 @@ namespace AWSIM.RandomTraffic
                                     state.YieldPhase = NPCVehicleYieldPhase.ON_YELDING_LANE;
                                     state.YieldPoint = GetStopPoint(currentLine, 1);
                                     state.YieldLane = currentLine;
+                                    break;
                                 }
                             }
                             break;
@@ -342,7 +344,6 @@ namespace AWSIM.RandomTraffic
                             state.DominatingVehicle = dominatingVehicle;
                             if (!shouldYield)
                                 state.YieldPhase = NPCVehicleYieldPhase.NONE;
-
                             break;
                     }
                 }

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleControlStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleControlStep.cs
@@ -51,6 +51,10 @@ namespace AWSIM.RandomTraffic
                     targetSpeed = 0f;
                     acceleration = config.SuddenDeceleration;
                     break;
+                case NPCVehicleSpeedMode.ABSOLUTE_STOP:
+                    targetSpeed = 0f;
+                    acceleration = config.AbsoluteDeceleration;
+                    break;
                 case NPCVehicleSpeedMode.STOP:
                     targetSpeed = 0f;
                     acceleration = config.Deceleration;

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
@@ -61,7 +61,7 @@ namespace AWSIM.RandomTraffic
             var stopDistance = CalculateStoppableDistance(state.Speed, config.Deceleration) + 3 * MinStopDistance;
             var slowDownDistance = stopDistance + 4 * MinStopDistance;
 
-            var distanceToStopPointByFrontVehicle = state.DistanceToFrontVehicle - MinFrontVehicleDistance;
+            var distanceToStopPointByFrontVehicle = onlyGeatherThan(state.DistanceToFrontVehicle - MinFrontVehicleDistance, 0);
             var distanceToStopPointByTrafficLight = CalculateTrafficLightDistance(state, suddenStopDistance);
             var distanceToStopPointByRightOfWay = CalculateYeldingDistance(state);
             var distanceToStopPoint = Mathf.Min(distanceToStopPointByFrontVehicle, distanceToStopPointByTrafficLight, distanceToStopPointByRightOfWay);
@@ -114,7 +114,7 @@ namespace AWSIM.RandomTraffic
                         break;
                 }
             }
-            return distanceToStopPointByTrafficLight;
+            return onlyGeatherThan(distanceToStopPointByTrafficLight, 0);
         }
 
         private static float CalculateYeldingDistance(NPCVehicleInternalState state)
@@ -122,13 +122,16 @@ namespace AWSIM.RandomTraffic
             var distanceToStopPointByRightOfWay = float.MaxValue;
             if (state.YieldPhase == NPCVehicleYieldPhase.YIELDING)
                 distanceToStopPointByRightOfWay = state.SignedDistanceToPointOnLane(state.YieldPoint);
-            return distanceToStopPointByRightOfWay;
+            return onlyGeatherThan(distanceToStopPointByRightOfWay, 0);
         }
 
         private static float CalculateStoppableDistance(float speed, float deceleration)
         {
-            return speed * speed / 2f / deceleration;
+            return onlyGeatherThan(speed * speed / 2f / deceleration, 0);
         }
+
+        private static float onlyGeatherThan(float value, float min_value = 0)
+        { return value >= min_value ? value : float.MaxValue; }
 
         public void ShowGizmos(IReadOnlyList<NPCVehicleInternalState> states)
         {

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
@@ -14,6 +14,7 @@ namespace AWSIM.RandomTraffic
         // MinFrontVehicleDistance is added to the threshold for the distance at which an obstacle is considered dangerous.
         // The vehicle is controlled to stop at this distance away from the obstacle(e.g. another vehicle in front of the vehicle).
         private const float MinFrontVehicleDistance = 4f;
+        private const float MinStopDistance = 0.5f;
 
         public NPCVehicleDecisionStep(NPCVehicleConfig config)
         {
@@ -47,23 +48,33 @@ namespace AWSIM.RandomTraffic
         /// - SLOW when the vehicle is in a sharp curve, needs to keep distance from a front vehicle or is entering yielding lane.<br/>
         /// - STOP when the vehicle can stop safely at a stop point(e.g. a stop line or a point that an obstacle exists).<br/>
         /// - SUDDEN_STOP when the vehicle cannot stop safely at a stop point.<br/>
+        /// - ABSOLUTE_STOP when the vehicle cannot stop using SUDDEN_STOP<br/>
         /// - NORMAL under other conditions.
-        /// </summary>
+        // /// </summary>
         private static void UpdateSpeedMode(NPCVehicleInternalState state, NPCVehicleConfig config)
         {
             if (state.ShouldDespawn)
                 return;
 
-            var maxStoppableDistance =
-                Mathf.Max(CalculateStoppableDistance(state.Speed, config.Deceleration), 3f);
-            var minStoppableDistance =
-                Mathf.Max(CalculateStoppableDistance(state.Speed, config.SuddenDeceleration), 3f);
+            var absoluteStopDistance = CalculateStoppableDistance(state.Speed, config.AbsoluteDeceleration) + MinStopDistance;
+            var suddenStopDistance = CalculateStoppableDistance(state.Speed, config.SuddenDeceleration) + 2 * MinStopDistance;
+            var stopDistance = CalculateStoppableDistance(state.Speed, config.Deceleration) + 3 * MinStopDistance;
+            var slowDownDistance = stopDistance + 4 * MinStopDistance;
 
             var distanceToStopPointByFrontVehicle = state.DistanceToFrontVehicle - MinFrontVehicleDistance;
+            var distanceToStopPointByTrafficLight = CalculateTrafficLightDistance(state, suddenStopDistance);
+            var distanceToStopPointByRightOfWay = CalculateYeldingDistance(state);
+            var distanceToStopPoint = Mathf.Min(distanceToStopPointByFrontVehicle, distanceToStopPointByTrafficLight, distanceToStopPointByRightOfWay);
 
-            // Speed mode updated by front vehicle is SLOW or SUDDEN_STOP.
+            // Speed mode updated by front vehicle is SLOW or SUDDEN_STOP/ABSOLUTE_STOP.
             // STOP state is not used to prevent the state from changing every frame.
-            if (distanceToStopPointByFrontVehicle <= minStoppableDistance)
+            if (distanceToStopPointByFrontVehicle <= suddenStopDistance)
+            {
+                state.IsStoppedByFrontVehicle = true;
+                state.SpeedMode = NPCVehicleSpeedMode.ABSOLUTE_STOP;
+                return;
+            }
+            else if (distanceToStopPointByFrontVehicle <= stopDistance)
             {
                 state.IsStoppedByFrontVehicle = true;
                 state.SpeedMode = NPCVehicleSpeedMode.SUDDEN_STOP;
@@ -71,6 +82,20 @@ namespace AWSIM.RandomTraffic
             }
             state.IsStoppedByFrontVehicle = false;
 
+            if (distanceToStopPoint <= absoluteStopDistance)
+                state.SpeedMode = NPCVehicleSpeedMode.ABSOLUTE_STOP;
+            else if (distanceToStopPoint <= suddenStopDistance || state.YieldPhase == NPCVehicleYieldPhase.YIELDING)
+                state.SpeedMode = NPCVehicleSpeedMode.SUDDEN_STOP;
+            else if (distanceToStopPoint <= stopDistance)
+                state.SpeedMode = NPCVehicleSpeedMode.STOP;
+            else if (distanceToStopPoint <= slowDownDistance || state.IsTurning || state.YieldPhase == NPCVehicleYieldPhase.ENTERING_YIELDING_LANE)
+                state.SpeedMode = NPCVehicleSpeedMode.SLOW;
+            else
+                state.SpeedMode = NPCVehicleSpeedMode.NORMAL;
+        }
+
+        private static float CalculateTrafficLightDistance(NPCVehicleInternalState state, float suddenStopDistance)
+        {
             var distanceToStopPointByTrafficLight = float.MaxValue;
             if (state.TrafficLightLane != null)
             {
@@ -81,9 +106,7 @@ namespace AWSIM.RandomTraffic
                     case TrafficLightPassability.GREEN:
                         break;
                     case TrafficLightPassability.YELLOW:
-                        var canStopSafely = distanceToStopLine >= minStoppableDistance;
-                        if (!canStopSafely)
-                            break;
+                        if (distanceToStopLine < suddenStopDistance) break;
                         distanceToStopPointByTrafficLight = distanceToStopLine;
                         break;
                     case TrafficLightPassability.RED:
@@ -91,51 +114,15 @@ namespace AWSIM.RandomTraffic
                         break;
                 }
             }
+            return distanceToStopPointByTrafficLight;
+        }
 
+        private static float CalculateYeldingDistance(NPCVehicleInternalState state)
+        {
             var distanceToStopPointByRightOfWay = float.MaxValue;
             if (state.YieldPhase == NPCVehicleYieldPhase.YIELDING)
-            {
                 distanceToStopPointByRightOfWay = state.SignedDistanceToPointOnLane(state.YieldPoint);
-            }
-
-            var distanceToStopPoint = Mathf.Min(
-                distanceToStopPointByTrafficLight,
-                distanceToStopPointByRightOfWay);
-
-            // Sudden stop if the vehicle cannot stop safely.
-            var shouldStopSuddenly =
-                distanceToStopPoint <= minStoppableDistance ||
-                state.YieldPhase == NPCVehicleYieldPhase.YIELDING;
-            if (shouldStopSuddenly)
-            {
-                state.SpeedMode = NPCVehicleSpeedMode.SUDDEN_STOP;
-                return;
-            }
-
-            // Stop normally when the vehicle is reaching stop point.
-            var shouldStopNormally =
-                distanceToStopPoint <= maxStoppableDistance;
-            if (shouldStopNormally)
-            {
-                state.SpeedMode = NPCVehicleSpeedMode.STOP;
-                return;
-            }
-
-            var shouldSlowDownByRightOfWay =
-                state.YieldPhase == NPCVehicleYieldPhase.ENTERING_YIELDING_LANE;
-
-            var shouldSlowDown =
-                // Should slow down by front vehicle (for keeping distance)
-                state.DistanceToFrontVehicle <= maxStoppableDistance + MinFrontVehicleDistance ||
-                shouldSlowDownByRightOfWay ||
-                state.IsTurning;
-            if (shouldSlowDown)
-            {
-                state.SpeedMode = NPCVehicleSpeedMode.SLOW;
-                return;
-            }
-
-            state.SpeedMode = NPCVehicleSpeedMode.NORMAL;
+            return distanceToStopPointByRightOfWay;
         }
 
         private static float CalculateStoppableDistance(float speed, float deceleration)
@@ -149,6 +136,7 @@ namespace AWSIM.RandomTraffic
             {
                 switch (state.SpeedMode)
                 {
+                    case NPCVehicleSpeedMode.ABSOLUTE_STOP:
                     case NPCVehicleSpeedMode.SUDDEN_STOP:
                     case NPCVehicleSpeedMode.STOP:
                         Gizmos.color = Color.red;

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleVisualizationStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleVisualizationStep.cs
@@ -24,21 +24,19 @@ namespace AWSIM.RandomTraffic
             var cullingInterval = 1.0f / cullingHz;
             cullingInterval -= 0.00001f;       // Allow for accuracy errors.
 
-            foreach (var state in states)
+            // Apply culling
+            if (cullingTimer < cullingInterval)
             {
-                // Apply culling
-                if (cullingTimer < cullingInterval)
+                foreach (var state in states)
                 {
                     if (Vector3.Distance(state.Vehicle.transform.position, egoVehicle.position) < cullingDistance)
                         state.Vehicle.SetActiveVisualObjects(true);
                     else
                         state.Vehicle.SetActiveVisualObjects(false);
-
-                    cullingTimer = 0;
+                    ApplyPose(state);
+                    ApplyTurnSignalState(state);
                 }
-
-                ApplyPose(state);
-                ApplyTurnSignalState(state);
+                cullingTimer = 0;
             }
 
             cullingTimer += Time.deltaTime;

--- a/Assets/AWSIM/Scripts/RandomTraffic/RandomTrafficSimulator.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/RandomTrafficSimulator.cs
@@ -18,9 +18,9 @@ namespace AWSIM.RandomTraffic
         [SerializeField] private LayerMask vehicleLayerMask;
         [SerializeField] private LayerMask groundLayerMask;
 
-        [SerializeField, Tooltip("Culling NPCs that are more than this distance from the EgoVehicle")] 
+        [SerializeField, Tooltip("Culling NPCs that are more than this distance from the EgoVehicle")]
         private float cullingDistance = 100;
-        [SerializeField, Tooltip("Hz to consider Culling")] 
+        [SerializeField, Tooltip("Hz to consider Culling")]
         private float cullingHz = 3;
 
         [Header("NPC Vehicle Settings")]
@@ -33,6 +33,7 @@ namespace AWSIM.RandomTraffic
         [Header("Debug")]
         [SerializeField] private bool showGizmos = false;
 
+        private uint numberSpawnedVehicles = 0;
         private NPCVehicleSpawner npcVehicleSpawner;
         private NPCVehicleSimulator npcVehicleSimulator;
 
@@ -74,7 +75,7 @@ namespace AWSIM.RandomTraffic
             if (!npcVehicleSpawner.TryGetRandomSpawnablePoint(prefab, out var spawnPoint))
                 return;
 
-            var vehicle = npcVehicleSpawner.Spawn(prefab, spawnPoint);
+            var vehicle = npcVehicleSpawner.Spawn(prefab, numberSpawnedVehicles++, spawnPoint);
             npcVehicleSimulator.Register(vehicle, spawnPoint.Lane, spawnPoint.WaypointIndex);
         }
 


### PR DESCRIPTION
I’ve noticed some issues, I have suggestions for consideration, I believe they can make the behavior of RandomTraffic better.
A more detailed description can be read [here]( https://tier4.atlassian.net/browse/AJD-708?focusedCommentId=115467).
## 1. Process of yielding at an intersection
### 1.1 Description
 - Numerous problems with yielding priority, especially when turning left, regardless of the intersection. Vehicles sometimes block each other, passing through each other and even disappearing into one another.
 - The problem occurs whenever the vehicle (2) to be yielded enters the intersection and vehicle (1) is already there - (2) is completely ignored by  - example:
![image](https://user-images.githubusercontent.com/121798334/223104092-a2de6f59-4772-4e04-ac5c-7ab1b948dc3c.png)
 - The presence or absence of a additional StopLine at an intersection (not before) is not related to this.
### 1.2 Assumption
 - Vehicles stop to yield the right of way only before an intersection - more specifically, before the TrafficLane containing RightOfWayLanes defined at the intersection.
 - After entering the intersection, yielding isn't checked anymore.
### 1.3 Causes
 - CognitionStep doesn't consider the currently FollowingLane, only the next one.
### 1.4 Solution suggestions
 - I believe that yielding should also be checked at the intersection.
 - For this purpose, the StopLane in the middle of the intersection or the first WayPoint of the current FollowLine can be used - as a definition of the position up to which yielding should be checked.
### 1.5 Implementation
 - I’ve implemented such solution and tested it (it can be seen here [NPCVehicleCognitionStep.cs](https://github.com/tier4/AWSIM/commit/8dcd9921cc5afd57df15a65e7c5f574506e6821f))
 - The step of checking yielding at the intersection I called it ON_YELDING_LANE.
 - I also added ignoring vehicles that have already passed the turning vehicle - allows to leave the intersection faster.
### 1.6 Results
 - I have noticed a significant improvement, the yielding issues are much less frequent.
 - The vehicle entering the intersection still checks the right-of-way and stops before the mentioned point.
 - However, there is still a chance that a vehicle from the opposite direction will enter after the turning vehicle has passed the StopLine (from ON_YELDING_LANE step).

## 2 Selection of set vehicle speed
### 2.1 Description
- Vehicles sometimes pass through each other, they don't seem to slow down sooner when they have the chance.
### 2.2 Assumption
- Vehicle speed control seems to be not always correct.
- Vehicles very often use the SUDDEN_STOP mode, SLOW rarely.
### 2.3 Causes
- UpdateSpeedMode method in DecisionStep seems to be unclear.
- Selected SpeedMode based on the defined min/max distance and conditions can sometimes be inappropriate for the situation.
### 2.4 Solution suggestions
- UpdateSpeedMode method refactor. Clear definition of several boundary distances. Ensuring that vehicles use SLOW more frequently.
### 2.5 Implementation
- I have implemented such solution and tested it (it can be seen here [NPCVehicleDecisionStep.cs](https://github.com/tier4/AWSIM/commit/6e415f6035cae5a9a777f296c224ccef7e1a7348))
- I added a SpeedMode that ensures the absolute stop of the vehicle, I called it ABSOLUTE_STOP.
- In theory, it should never be selected by the vehicle, so it should rather be used for detecting problems in the yield process - eg 2., where the vehicle forces the right of way.
- I’ve defined 4 distances, based on which one of 4 SpeedMode is selected: ABSOLUTE_STOP, SUDDEN_STOP, STOP, SLOW.
- I set the following acceleration values:
![image](https://user-images.githubusercontent.com/121798334/223103449-c08b95a2-eb3a-42dc-a517-8fbf552a46fc.png)
- I’ve separated the calculation of 3 specific distances and the SpeedMode selection process - which is based on the calculated one min distance. Everything seems to be clearer.
### 2.6 Results
- I’ve noticed that vehicles use all 3 speeds in a more realistic way - with real slowing and braking of the vehicle in city traffic.
- ABSOLUTE_STOP is only used in critical situations that should not occur.
- The table shows the obtained effect: