### PR TITLE
Disable lidars when RGL has unrecoverable error

### DIFF
--- a/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNativeAPI.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNativeAPI.cs
@@ -160,9 +160,19 @@ namespace RGLUnityPlugin
 
         public static void CheckErr(int status)
         {
-            if (status == 0)
+            if (status == (int)RGLStatus.SUCCESS)
             {
                 return;
+            }
+
+            if (status == (int)RGLStatus.INVALID_STATE)
+            {
+                foreach (LidarSensor rglLidar in UnityEngine.Object.FindObjectsOfType<LidarSensor>())
+                {
+                    rglLidar.enabled = false;
+                }
+                throw new RGLException("A previous unrecoverable error has corrupted RobotecGPULidar's internal state. "
+                                       + "Disabling LidarSensor components. The application must be restarted!");
             }
 
             rgl_get_last_error_string(out var errStrPtr);


### PR DESCRIPTION
Minor fix to stop printing tons of RGL exceptions when an unrecoverable error occurs. Now, lidar components will be disabled, and RGL API calls will not be sent anymore. It will help with debugging potential errors faster.