### PR TITLE
fix(random_traffic): fix spawn issue - distance_to_stop

### DIFF
--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
@@ -18,7 +18,7 @@ namespace AWSIM.RandomTraffic
         NONE,
         ENTERING_YIELDING_LANE,
         YIELDING,
-        ON_YELDING_LANE
+        ON_YIELDING_LANE
     }
 
     /// <summary>

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleCognitionStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleCognitionStep.cs
@@ -316,14 +316,14 @@ namespace AWSIM.RandomTraffic
                                 var currentLine = state.FollowingLanes[0];
                                 if (currentLine.RightOfWayLanes.Count > 0)
                                 {
-                                    state.YieldPhase = NPCVehicleYieldPhase.ON_YELDING_LANE;
+                                    state.YieldPhase = NPCVehicleYieldPhase.ON_YIELDING_LANE;
                                     state.YieldPoint = GetStopPoint(currentLine, 1);
                                     state.YieldLane = currentLine;
                                     break;
                                 }
                             }
                             break;
-                        case NPCVehicleYieldPhase.ON_YELDING_LANE:
+                        case NPCVehicleYieldPhase.ON_YIELDING_LANE:
                         case NPCVehicleYieldPhase.ENTERING_YIELDING_LANE:
                             // Do nothing if the vehicle is far from stop line
                             var signedDistanceToStopLine = state.SignedDistanceToPointOnLane(state.YieldPoint);

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
@@ -61,7 +61,7 @@ namespace AWSIM.RandomTraffic
             var stopDistance = CalculateStoppableDistance(state.Speed, config.Deceleration) + 3 * MinStopDistance;
             var slowDownDistance = stopDistance + 4 * MinStopDistance;
 
-            var distanceToStopPointByFrontVehicle = onlyGreaterThan(state.DistanceToFrontVehicle - MinFrontVehicleDistance, 0);
+            var distanceToStopPointByFrontVehicle = onlyGreaterThan(state.DistanceToFrontVehicle - MinFrontVehicleDistance, -MinFrontVehicleDistance);
             var distanceToStopPointByTrafficLight = CalculateTrafficLightDistance(state, suddenStopDistance);
             var distanceToStopPointByRightOfWay = CalculateYieldingDistance(state);
             var distanceToStopPoint = Mathf.Min(distanceToStopPointByFrontVehicle, distanceToStopPointByTrafficLight, distanceToStopPointByRightOfWay);

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
@@ -61,9 +61,9 @@ namespace AWSIM.RandomTraffic
             var stopDistance = CalculateStoppableDistance(state.Speed, config.Deceleration) + 3 * MinStopDistance;
             var slowDownDistance = stopDistance + 4 * MinStopDistance;
 
-            var distanceToStopPointByFrontVehicle = onlyGeatherThan(state.DistanceToFrontVehicle - MinFrontVehicleDistance, 0);
+            var distanceToStopPointByFrontVehicle = onlyGreaterThan(state.DistanceToFrontVehicle - MinFrontVehicleDistance, 0);
             var distanceToStopPointByTrafficLight = CalculateTrafficLightDistance(state, suddenStopDistance);
-            var distanceToStopPointByRightOfWay = CalculateYeldingDistance(state);
+            var distanceToStopPointByRightOfWay = CalculateYieldingDistance(state);
             var distanceToStopPoint = Mathf.Min(distanceToStopPointByFrontVehicle, distanceToStopPointByTrafficLight, distanceToStopPointByRightOfWay);
 
             // Speed mode updated by front vehicle is SLOW or SUDDEN_STOP/ABSOLUTE_STOP.
@@ -114,23 +114,23 @@ namespace AWSIM.RandomTraffic
                         break;
                 }
             }
-            return onlyGeatherThan(distanceToStopPointByTrafficLight, 0);
+            return onlyGreaterThan(distanceToStopPointByTrafficLight, 0);
         }
 
-        private static float CalculateYeldingDistance(NPCVehicleInternalState state)
+        private static float CalculateYieldingDistance(NPCVehicleInternalState state)
         {
             var distanceToStopPointByRightOfWay = float.MaxValue;
             if (state.YieldPhase == NPCVehicleYieldPhase.YIELDING)
                 distanceToStopPointByRightOfWay = state.SignedDistanceToPointOnLane(state.YieldPoint);
-            return onlyGeatherThan(distanceToStopPointByRightOfWay, 0);
+            return onlyGreaterThan(distanceToStopPointByRightOfWay, 0);
         }
 
         private static float CalculateStoppableDistance(float speed, float deceleration)
         {
-            return onlyGeatherThan(speed * speed / 2f / deceleration, 0);
+            return onlyGreaterThan(speed * speed / 2f / deceleration, 0);
         }
 
-        private static float onlyGeatherThan(float value, float min_value = 0)
+        private static float onlyGreaterThan(float value, float min_value = 0)
         { return value >= min_value ? value : float.MaxValue; }
 
         public void ShowGizmos(IReadOnlyList<NPCVehicleInternalState> states)


### PR DESCRIPTION
If the vehicle spawns close to the already existing vehicle, and this distance is smaller than `MinFrontVehicleDistance`, then the `distanceToStopPointByFrontVehicle` is in infinite, and spawned vehicle ignores everything in front of him.
This [commit](https://github.com/tier4/AWSIM/commit/2a7f8c4fd376b7f1fee9601c94433bb2536033db) fixes this problem - the distance to the front of vehicles is calculated correctly.
I also corrected some typos.

###  Main

https://github.com/tier4/AWSIM/assets/121798334/09eb8fab-4f7e-4335-ba13-9f4a6d35c50f

### Fixed

https://github.com/tier4/AWSIM/assets/121798334/7fed7157-8da4-4e0e-8967-3379429bea3e

