### PR TITLE
Improve lidar configuration

### DIFF
--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar40P.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar40P.prefab
@@ -477,7 +477,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b09121ab5f04a5dae5e27fd15e97c53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  material: {fileID: 0}
+  pointShape: 1
+  pointSize: 0.05
+  colors:
+  - {r: 1, g: 0, b: 0, a: 1}
+  - {r: 1, g: 0.5, b: 0, a: 1}
+  - {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  - {r: 0, g: 1, b: 0, a: 1}
+  - {r: 0, g: 0, b: 1, a: 1}
+  - {r: 0.5, g: 0, b: 1, a: 1}
+  autoComputeColoringHeights: 0
+  minColoringHeight: 0
+  maxColoringHeight: 20
 --- !u!114 &4243938545670296942
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -492,7 +503,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 6
-  applyGaussianNoise: 1
+  applyDistanceGaussianNoise: 1
+  applyAngularGaussianNoise: 1
   configuration:
     laserArray:
       centerOfMeasurementVerticalLinearOffsetMm: 47.7
@@ -659,8 +671,8 @@ MonoBehaviour:
         verticalLinearOffsetMm: 0
         ringId: 40
     horizontalSteps: 1800
-    minHAngle: -180
-    maxHAngle: 180
+    minHAngle: 0
+    maxHAngle: 360
     maxRange: 200
     noiseParams:
       angularNoiseType: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar40P.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar40P.prefab
@@ -460,11 +460,10 @@ MonoBehaviour:
   frameID: world
   publishPCL24: 1
   publishPCL48: 1
-  qosSettings:
-    ReliabilityPolicy: 1
-    DurabilityPolicy: 2
-    HistoryPolicy: 1
-    Depth: 1000
+  reliabilityPolicy: 2
+  durabilityPolicy: 2
+  historyPolicy: 1
+  historyDepth: 5
 --- !u!114 &7675420128049466981
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -670,7 +669,7 @@ MonoBehaviour:
         verticalAngularOffsetDeg: -15
         verticalLinearOffsetMm: 0
         ringId: 40
-    horizontalSteps: 1800
+    horizontalResolution: 0.2
     minHAngle: 0
     maxHAngle: 360
     maxRange: 200

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarQT64.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarQT64.prefab
@@ -363,11 +363,10 @@ MonoBehaviour:
   frameID: world
   publishPCL24: 1
   publishPCL48: 1
-  qosSettings:
-    ReliabilityPolicy: 1
-    DurabilityPolicy: 2
-    HistoryPolicy: 1
-    Depth: 1000
+  reliabilityPolicy: 2
+  durabilityPolicy: 2
+  historyPolicy: 1
+  historyDepth: 5
 --- !u!114 &1430391258634731476
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -380,7 +379,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b09121ab5f04a5dae5e27fd15e97c53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  material: {fileID: 0}
+  pointShape: 1
+  pointSize: 0.05
+  colors:
+  - {r: 1, g: 0, b: 0, a: 1}
+  - {r: 1, g: 0.5, b: 0, a: 1}
+  - {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  - {r: 0, g: 1, b: 0, a: 1}
+  - {r: 0, g: 0, b: 1, a: 1}
+  - {r: 0.5, g: 0, b: 1, a: 1}
+  autoComputeColoringHeights: 0
+  minColoringHeight: 0
+  maxColoringHeight: 20
 --- !u!114 &5660981340522876577
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -395,7 +405,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 5
-  applyGaussianNoise: 1
+  applyDistanceGaussianNoise: 1
+  applyAngularGaussianNoise: 1
   configuration:
     laserArray:
       centerOfMeasurementVerticalLinearOffsetMm: 50.4
@@ -658,8 +669,8 @@ MonoBehaviour:
         verticalLinearOffsetMm: 0
         ringId: 64
     horizontalSteps: 600
-    minHAngle: -180
-    maxHAngle: 180
+    minHAngle: 0
+    maxHAngle: 360
     maxRange: 20
     noiseParams:
       angularNoiseType: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarQT64.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarQT64.prefab
@@ -668,7 +668,7 @@ MonoBehaviour:
         verticalAngularOffsetDeg: -52.133
         verticalLinearOffsetMm: 0
         ringId: 64
-    horizontalSteps: 600
+    horizontalResolution: 0.6
     minHAngle: 0
     maxHAngle: 360
     maxRange: 20

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/OusterOS1-64.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/OusterOS1-64.prefab
@@ -51,11 +51,10 @@ MonoBehaviour:
   frameID: world
   publishPCL24: 1
   publishPCL48: 1
-  qosSettings:
-    ReliabilityPolicy: 1
-    DurabilityPolicy: 2
-    HistoryPolicy: 1
-    Depth: 1000
+  reliabilityPolicy: 2
+  durabilityPolicy: 2
+  historyPolicy: 1
+  historyDepth: 5
 --- !u!114 &4572956135196922574
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -68,7 +67,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b09121ab5f04a5dae5e27fd15e97c53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  material: {fileID: 0}
+  pointShape: 1
+  pointSize: 0.05
+  colors:
+  - {r: 1, g: 0, b: 0, a: 1}
+  - {r: 1, g: 0.5, b: 0, a: 1}
+  - {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  - {r: 0, g: 1, b: 0, a: 1}
+  - {r: 0, g: 0, b: 1, a: 1}
+  - {r: 0.5, g: 0, b: 1, a: 1}
+  autoComputeColoringHeights: 0
+  minColoringHeight: 0
+  maxColoringHeight: 20
 --- !u!114 &141188791316208376
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -83,7 +93,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 20
   modelPreset: 7
-  applyGaussianNoise: 1
+  applyDistanceGaussianNoise: 1
+  applyAngularGaussianNoise: 1
   configuration:
     laserArray:
       centerOfMeasurementVerticalLinearOffsetMm: 36.18
@@ -346,8 +357,8 @@ MonoBehaviour:
         verticalLinearOffsetMm: 0
         ringId: 64
     horizontalSteps: 1024
-    minHAngle: -180
-    maxHAngle: 180
+    minHAngle: 0
+    maxHAngle: 360
     maxRange: 120
     noiseParams:
       angularNoiseType: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/OusterOS1-64.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/OusterOS1-64.prefab
@@ -356,7 +356,7 @@ MonoBehaviour:
         verticalAngularOffsetDeg: 16.598
         verticalLinearOffsetMm: 0
         ringId: 64
-    horizontalSteps: 1024
+    horizontalResolution: 0.3515625
     minHAngle: 0
     maxHAngle: 360
     maxRange: 120

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
@@ -52,11 +52,10 @@ MonoBehaviour:
   frameID: world
   publishPCL24: 1
   publishPCL48: 1
-  qosSettings:
-    ReliabilityPolicy: 1
-    DurabilityPolicy: 2
-    HistoryPolicy: 1
-    Depth: 1000
+  reliabilityPolicy: 2
+  durabilityPolicy: 2
+  historyPolicy: 1
+  historyDepth: 5
 --- !u!114 &4572956135196922574
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -69,7 +68,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b09121ab5f04a5dae5e27fd15e97c53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  material: {fileID: 0}
+  pointShape: 1
+  pointSize: 0.05
+  colors:
+  - {r: 1, g: 0, b: 0, a: 1}
+  - {r: 1, g: 0.5, b: 0, a: 1}
+  - {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  - {r: 0, g: 1, b: 0, a: 1}
+  - {r: 0, g: 0, b: 1, a: 1}
+  - {r: 0.5, g: 0, b: 1, a: 1}
+  autoComputeColoringHeights: 0
+  minColoringHeight: 0
+  maxColoringHeight: 20
 --- !u!114 &141188791316208376
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -82,9 +92,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62277ad5b6d1cfd2984db58dc79535a4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  OutputHz: 10
+  AutomaticCaptureHz: 10
   modelPreset: 2
-  applyGaussianNoise: 1
+  applyDistanceGaussianNoise: 1
+  applyAngularGaussianNoise: 1
   configuration:
     laserArray:
       centerOfMeasurementVerticalLinearOffsetMm: 37.7
@@ -155,8 +166,8 @@ MonoBehaviour:
         verticalLinearOffsetMm: 11.2
         ringId: 16
     horizontalSteps: 1800
-    minHAngle: -180
-    maxHAngle: 180
+    minHAngle: 0
+    maxHAngle: 360
     maxRange: 100
     noiseParams:
       angularNoiseType: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
@@ -165,7 +165,7 @@ MonoBehaviour:
         verticalAngularOffsetDeg: -15
         verticalLinearOffsetMm: 11.2
         ringId: 16
-    horizontalSteps: 1800
+    horizontalResolution: 0.2
     minHAngle: 0
     maxHAngle: 360
     maxRange: 100

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP32C.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP32C.prefab
@@ -229,7 +229,7 @@ MonoBehaviour:
         verticalAngularOffsetDeg: 1.333
         verticalLinearOffsetMm: 0
         ringId: 32
-    horizontalSteps: 1800
+    horizontalResolution: 0.2
     minHAngle: 0
     maxHAngle: 360
     maxRange: 200

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP32C.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP32C.prefab
@@ -52,11 +52,10 @@ MonoBehaviour:
   frameID: world
   publishPCL24: 1
   publishPCL48: 1
-  qosSettings:
-    ReliabilityPolicy: 1
-    DurabilityPolicy: 2
-    HistoryPolicy: 1
-    Depth: 1000
+  reliabilityPolicy: 2
+  durabilityPolicy: 2
+  historyPolicy: 1
+  historyDepth: 5
 --- !u!114 &6422033487030486066
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -69,7 +68,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b09121ab5f04a5dae5e27fd15e97c53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  material: {fileID: 0}
+  pointShape: 1
+  pointSize: 0.05
+  colors:
+  - {r: 1, g: 0, b: 0, a: 1}
+  - {r: 1, g: 0.5, b: 0, a: 1}
+  - {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  - {r: 0, g: 1, b: 0, a: 1}
+  - {r: 0, g: 0, b: 1, a: 1}
+  - {r: 0.5, g: 0, b: 1, a: 1}
+  autoComputeColoringHeights: 0
+  minColoringHeight: 0
+  maxColoringHeight: 20
 --- !u!114 &6177771126420573330
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -84,7 +94,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 3
-  applyGaussianNoise: 1
+  applyDistanceGaussianNoise: 1
+  applyAngularGaussianNoise: 1
   configuration:
     laserArray:
       centerOfMeasurementVerticalLinearOffsetMm: 37.34
@@ -219,8 +230,8 @@ MonoBehaviour:
         verticalLinearOffsetMm: 0
         ringId: 32
     horizontalSteps: 1800
-    minHAngle: -180
-    maxHAngle: 180
+    minHAngle: 0
+    maxHAngle: 360
     maxRange: 200
     noiseParams:
       angularNoiseType: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLS128.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLS128.prefab
@@ -460,11 +460,10 @@ MonoBehaviour:
   frameID: world
   publishPCL24: 1
   publishPCL48: 1
-  qosSettings:
-    ReliabilityPolicy: 1
-    DurabilityPolicy: 2
-    HistoryPolicy: 1
-    Depth: 1000
+  reliabilityPolicy: 2
+  durabilityPolicy: 2
+  historyPolicy: 1
+  historyDepth: 5
 --- !u!114 &6012075883028567972
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -477,7 +476,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b09121ab5f04a5dae5e27fd15e97c53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  material: {fileID: 0}
+  pointShape: 1
+  pointSize: 0.05
+  colors:
+  - {r: 1, g: 0, b: 0, a: 1}
+  - {r: 1, g: 0.5, b: 0, a: 1}
+  - {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  - {r: 0, g: 1, b: 0, a: 1}
+  - {r: 0, g: 0, b: 1, a: 1}
+  - {r: 0.5, g: 0, b: 1, a: 1}
+  autoComputeColoringHeights: 0
+  minColoringHeight: 0
+  maxColoringHeight: 20
 --- !u!114 &556645941698395683
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -492,7 +502,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 4
-  applyGaussianNoise: 1
+  applyDistanceGaussianNoise: 1
+  applyAngularGaussianNoise: 1
   configuration:
     laserArray:
       centerOfMeasurementVerticalLinearOffsetMm: 66.11
@@ -1011,8 +1022,8 @@ MonoBehaviour:
         verticalLinearOffsetMm: 0
         ringId: 76
     horizontalSteps: 1800
-    minHAngle: -180
-    maxHAngle: 180
+    minHAngle: 0
+    maxHAngle: 360
     maxRange: 300
     noiseParams:
       angularNoiseType: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLS128.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLS128.prefab
@@ -1021,7 +1021,7 @@ MonoBehaviour:
         verticalAngularOffsetDeg: -0.43
         verticalLinearOffsetMm: 0
         ringId: 76
-    horizontalSteps: 1800
+    horizontalResolution: 0.2
     minHAngle: 0
     maxHAngle: 360
     maxRange: 300

--- a/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfiguration.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfiguration.cs
@@ -34,12 +34,12 @@ namespace RGLUnityPlugin
         /// <summary>
         /// Min horizontal angle (left)
         /// </summary>
-        public float minHAngle;
+        [Range(-360.0f, 360.0f)] public float minHAngle;
 
         /// <summary>
         /// Max horizontal angle (right)
         /// </summary>
-        public float maxHAngle;
+        [Range(-360.0f, 360.0f)] public float maxHAngle;
 
         /// <summary>
         /// Maximum range of the sensor.
@@ -59,6 +59,12 @@ namespace RGLUnityPlugin
             {
                 throw new ArgumentOutOfRangeException(nameof(minHAngle),
                     "Minimum angle must be lower or equal to maximum angle");
+            }
+
+            if (maxHAngle - minHAngle > 360.0f)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxHAngle),
+                    "Horizontal range must be lower than 360 degrees");
             }
 
             if (!(horizontalSteps > 0))

--- a/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfigurationLibrary.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfigurationLibrary.cs
@@ -34,7 +34,7 @@ namespace RGLUnityPlugin
         public static LidarConfiguration RangeMeter => new LidarConfiguration
         {
             laserArray = LaserArray.Uniform(-0.0f, 0.0f, 1),
-            horizontalSteps = 1,
+            horizontalResolution = 1.0f,
             minHAngle = -0,
             maxHAngle = 0,
             maxRange = 40,
@@ -44,7 +44,7 @@ namespace RGLUnityPlugin
         public static LidarConfiguration SickMRS6000 => new LidarConfiguration
         {
             laserArray = LaserArray.Uniform(-15f, 1.5f, 24),
-            horizontalSteps = 924,
+            horizontalResolution = 240.0f / 924.0f,
             minHAngle = -120,
             maxHAngle = 120,
             maxRange = 40,
@@ -54,7 +54,7 @@ namespace RGLUnityPlugin
         public static LidarConfiguration VelodyneVLP16 => new LidarConfiguration
         {
             laserArray = LaserArrayLibrary.VelodyneVLP16,
-            horizontalSteps = 360 * 5, // for 0.2deg resolution
+            horizontalResolution = 0.2f,
             minHAngle = 0.0f,
             maxHAngle = 360.0f,
             maxRange = 100.0f,
@@ -64,7 +64,7 @@ namespace RGLUnityPlugin
         public static LidarConfiguration VelodyneVLP32C => new LidarConfiguration
         {
             laserArray = LaserArrayLibrary.VelodyneVLP32C,
-            horizontalSteps = 360 * 5, // for 0.2deg resolution
+            horizontalResolution = 0.2f,
             minHAngle = 0.0f,
             maxHAngle = 360.0f,
             maxRange = 200.0f,
@@ -74,7 +74,7 @@ namespace RGLUnityPlugin
         public static LidarConfiguration VelodyneVLS128 => new LidarConfiguration
         {
             laserArray = LaserArrayLibrary.VelodyneVLS128,
-            horizontalSteps = 360 * 5, // for 0.2deg resolution
+            horizontalResolution = 0.2f,
             minHAngle = 0.0f,
             maxHAngle = 360.0f,
             maxRange = 300.0f,
@@ -84,7 +84,7 @@ namespace RGLUnityPlugin
         public static LidarConfiguration HesaiPandarQT => new LidarConfiguration
         {
             laserArray = LaserArrayLibrary.HesaiPandarQT,
-            horizontalSteps = 600, // for 0.6deg resolution
+            horizontalResolution = 0.6f,
             minHAngle = 0.0f,
             maxHAngle = 360.0f,
             maxRange = 20.0f, // Yes, 20 meters, this is not a typo!
@@ -94,7 +94,7 @@ namespace RGLUnityPlugin
         public static LidarConfiguration HesaiPandar40P => new LidarConfiguration
         {
             laserArray = LaserArrayLibrary.HesaiPandar40P,
-            horizontalSteps = 360 * 5, // for 0.2deg resolution
+            horizontalResolution = 0.2f,
             minHAngle = 0.0f,
             maxHAngle = 360.0f,
             // documentation is unclear on max range;
@@ -109,7 +109,7 @@ namespace RGLUnityPlugin
         public static LidarConfiguration OusterOS1_64 => new LidarConfiguration
         {
             laserArray = LaserArrayLibrary.OusterOS1_64,
-            horizontalSteps = 1024,
+            horizontalResolution = 360.0f / 1024.0f,
             minHAngle = 0.0f,
             maxHAngle = 360.0f,
             maxRange = 120.0f,

--- a/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfigurationLibrary.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfigurationLibrary.cs
@@ -55,8 +55,8 @@ namespace RGLUnityPlugin
         {
             laserArray = LaserArrayLibrary.VelodyneVLP16,
             horizontalSteps = 360 * 5, // for 0.2deg resolution
-            minHAngle = -180.0f,
-            maxHAngle = 180.0f,
+            minHAngle = 0.0f,
+            maxHAngle = 360.0f,
             maxRange = 100.0f,
             noiseParams = LidarConfiguration.TypicalNoiseParams,
         };
@@ -65,8 +65,8 @@ namespace RGLUnityPlugin
         {
             laserArray = LaserArrayLibrary.VelodyneVLP32C,
             horizontalSteps = 360 * 5, // for 0.2deg resolution
-            minHAngle = -180.0f,
-            maxHAngle = 180.0f,
+            minHAngle = 0.0f,
+            maxHAngle = 360.0f,
             maxRange = 200.0f,
             noiseParams = LidarConfiguration.TypicalNoiseParams,
         };
@@ -75,8 +75,8 @@ namespace RGLUnityPlugin
         {
             laserArray = LaserArrayLibrary.VelodyneVLS128,
             horizontalSteps = 360 * 5, // for 0.2deg resolution
-            minHAngle = -180.0f,
-            maxHAngle = 180.0f,
+            minHAngle = 0.0f,
+            maxHAngle = 360.0f,
             maxRange = 300.0f,
             noiseParams = LidarConfiguration.TypicalNoiseParams,
         };
@@ -85,8 +85,8 @@ namespace RGLUnityPlugin
         {
             laserArray = LaserArrayLibrary.HesaiPandarQT,
             horizontalSteps = 600, // for 0.6deg resolution
-            minHAngle = -180.0f,
-            maxHAngle = 180.0f,
+            minHAngle = 0.0f,
+            maxHAngle = 360.0f,
             maxRange = 20.0f, // Yes, 20 meters, this is not a typo!
             noiseParams = LidarConfiguration.TypicalNoiseParams,
         };
@@ -95,8 +95,8 @@ namespace RGLUnityPlugin
         {
             laserArray = LaserArrayLibrary.HesaiPandar40P,
             horizontalSteps = 360 * 5, // for 0.2deg resolution
-            minHAngle = -180.0f,
-            maxHAngle = 180.0f,
+            minHAngle = 0.0f,
+            maxHAngle = 360.0f,
             // documentation is unclear on max range;
             // on one hand there is "range capability" = 200m
             // on the other, in appendix beams have individual ranges assigned
@@ -110,8 +110,8 @@ namespace RGLUnityPlugin
         {
             laserArray = LaserArrayLibrary.OusterOS1_64,
             horizontalSteps = 1024,
-            minHAngle = -180.0f,
-            maxHAngle = 180.0f,
+            minHAngle = 0.0f,
+            maxHAngle = 360.0f,
             maxRange = 120.0f,
             noiseParams = LidarConfiguration.TypicalNoiseParams,
         };


### PR DESCRIPTION
- Added limits to horizontal angles (-360 to 360).
- Added horizontal range validation (cannot exceed 360 degrees).
- Fixed start angles of Hesai, Ouster, and Velodyne lidars to match their real-world configuration.
- Replaced horizontal steps GUI parameter with horizontal resolution.