### PR TITLE
docs: add LaneletBoundsVisualizer document

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - AWSIM Environment: Components/Environment/AWSIMEnvironment/index.md
       - Add New Environment: Components/Environment/AddNewEnvironment/index.md
       - PointCloudMapper: Components/Environment/PointCloudMapper/index.md
+      - LaneletBoundsVisualizer: Components/Environment/LaneletBoundsVisualizer/index.md
     - Traffic:
       - Random Traffic:
         - Random Traffic Simulator: Components/Traffic/RandomTraffic/RandomTrafficSimulator/index.md


### PR DESCRIPTION
The LaneletBoundsVisualizer document was not showing up in the AWSIM Documentation page since I forgot to edit the mkdocs.yml in the previous Pull Request.

The problem is solved with this pull request.