### PR TITLE
Fix horizontal steps calculation from the horizontal resolution

### DIFF
--- a/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfiguration.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfiguration.cs
@@ -51,7 +51,7 @@ namespace RGLUnityPlugin
         /// </summary>
         public LidarNoiseParams noiseParams;
 
-        public int HorizontalSteps => Math.Max((int)((maxHAngle - minHAngle) / horizontalResolution), 1);
+        public int HorizontalSteps => Math.Max((int)Math.Round(((maxHAngle - minHAngle) / horizontalResolution)), 1);
         public int PointCloudSize => laserArray.lasers.Length * HorizontalSteps;
 
         public Matrix4x4[] GetRayPoses()


### PR DESCRIPTION
Float to int conversion drops the fractional part of the number. For some nicely divisible values, it understates the result (e.g., 0.2 degrees of resolution: 360 / 0.2 = 1800, but it returns 1799). I used `Math.Round` to fix it.