### PR TITLE
Fix laser poses to be generated in the LiDAR origin

### DIFF
--- a/Assets/RGLUnityPlugin/Scripts/LidarModels/LaserArray.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarModels/LaserArray.cs
@@ -33,6 +33,7 @@ namespace RGLUnityPlugin
         //  |                     |        v
         //  ._____________________.  - - - -
         //             |
+        // This offset is not considered when generating laser poses. To be applied manually when setting the pose of the lidar.
         public float centerOfMeasurementVerticalLinearOffsetMm;
 
         //             |           /
@@ -55,7 +56,7 @@ namespace RGLUnityPlugin
         public Laser[] lasers;
 
         /// <summary>
-        /// Returns poses of lasers relative to the LiDAR origin.
+        /// Returns poses of lasers relative to the attached game object origin.
         /// </summary>
         public Matrix4x4[] GetLaserPoses()
         {
@@ -65,8 +66,7 @@ namespace RGLUnityPlugin
             // expression, local function or query expression and using the local instead.
             LaserArray self = this;
             return lasers.Select(
-                laser => Matrix4x4.Translate(Vector3.up * mmToMeters(self.centerOfMeasurementVerticalLinearOffsetMm) +
-                                             Vector3.up * mmToMeters(laser.verticalLinearOffsetMm) +
+                laser => Matrix4x4.Translate(Vector3.up * mmToMeters(laser.verticalLinearOffsetMm) +
                                              Vector3.forward *
                                              mmToMeters(self.centerOfMeasurementHorizontalLinearOffsetMm))
                          * Matrix4x4.Rotate(Quaternion.Euler(laser.verticalAngularOffsetDeg,

--- a/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfiguration.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfiguration.cs
@@ -90,6 +90,14 @@ namespace RGLUnityPlugin
             return rayPose;
         }
 
+        /// <summary>
+        /// Returns transform from the attached game object to the LiDAR origin.
+        /// </summary>
+        public Matrix4x4 GetLidarOriginTransfrom()
+        {
+            return Matrix4x4.Translate(Vector3.up * (laserArray.centerOfMeasurementVerticalLinearOffsetMm / 1000.0f));
+        }
+
         public static LidarNoiseParams TypicalNoiseParams => new LidarNoiseParams
         {
             angularNoiseType = AngularNoiseType.RayBased,

--- a/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
@@ -194,7 +194,7 @@ namespace RGLUnityPlugin
             sceneManager.DoUpdate();
 
             // Set lidar pose
-            Matrix4x4 lidarPose = gameObject.transform.localToWorldMatrix;
+            Matrix4x4 lidarPose = gameObject.transform.localToWorldMatrix * configuration.GetLidarOriginTransfrom();
             rglGraphLidar.UpdateNodeRaysTransform(lidarPoseNodeId, lidarPose);
             rglSubgraphToLidarFrame.UpdateNodePointsTransform(toLidarFrameNodeId, lidarPose.inverse);
 


### PR DESCRIPTION
Before this PR, laser poses were generated in the lidar game object origin with the translation to match LiDAR origin (the center of measurement vertical linear offset). It caused wrong distance calculation.
Now, laser poses are generated without respecting `centerOfMeasurementVerticalLinearOffsetMm`, and that transform (from the game object to the LiDAR origin) is applied when setting the pose of the LiDAR.