### PR TITLE
Fix broken link to OpenSSL

### DIFF
--- a/docs/GettingStarted/SetupUnityProject/index.md
+++ b/docs/GettingStarted/SetupUnityProject/index.md
@@ -84,7 +84,7 @@ To open the Unity AWSIM project in Unity Editor:
     If you get the safe mode dialog when starting UnityEditor, you may need to install openssl.
 
     1. download libssl  
-    `$ wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.12_amd64.deb`
+    `$ wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.13_amd64.deb`
     2. install  
     `sudo dpkg -i libssl1.0.0_1.0.2n-1ubuntu5.11_amd64.deb`
 


### PR DESCRIPTION
The current link for `openssl` (https://tier4.github.io/AWSIM/GettingStarted/SetupUnityProject/) does not work.
```
▶ wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.12_amd64.deb
--2023-06-07 22:07:01--  http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.12_amd64.deb
Resolving security.ubuntu.com (security.ubuntu.com)... 2620:2d:4000:1::16, 2620:2d:4000:1::19, 2001:67c:1562::15, ...
Connecting to security.ubuntu.com (security.ubuntu.com)|2620:2d:4000:1::16|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-06-07 22:07:01 ERROR 404: Not Found
```
It looks like the version was recently updated from `12` to `13`. This PR simply updates the version number in the link.