### PR TITLE
refactor: use control_cmd_auto instead

### DIFF
--- a/Assets/AWSIM/Prefabs/Vehicles/Lexus RX450h 2015 Sample Sensor.prefab
+++ b/Assets/AWSIM/Prefabs/Vehicles/Lexus RX450h 2015 Sample Sensor.prefab
@@ -1849,7 +1849,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   turnIndicatorsCommandTopic: /control/command/turn_indicators_cmd
   hazardLightsCommandTopic: /control/command/hazard_lights_cmd
-  ackermannControlCommandTopic: /control/command/control_cmd
+  ackermannControlCommandTopic: /control/command/control_cmd_auto
   gearCommandTopic: /control/command/gear_cmd
   vehicleEmergencyStampedTopic: /control/command/emergency_cmd
   qosSettings:

--- a/Assets/AWSIM/Scripts/Vehicles/VehicleRosInput.cs
+++ b/Assets/AWSIM/Scripts/Vehicles/VehicleRosInput.cs
@@ -14,7 +14,7 @@ namespace AWSIM
     {
         [SerializeField] string turnIndicatorsCommandTopic = "/control/command/turn_indicators_cmd";
         [SerializeField] string hazardLightsCommandTopic = "/control/command/hazard_lights_cmd";
-        [SerializeField] string ackermannControlCommandTopic = "/control/command/control_cmd";
+        [SerializeField] string ackermannControlCommandTopic = "/control/command/control_cmd_auto";
         [SerializeField] string gearCommandTopic = "/control/command/gear_cmd";
         [SerializeField] string vehicleEmergencyStampedTopic = "/control/command/emergency_cmd";
 

--- a/docs/Components/ROS2/ROS2TopicList/index.md
+++ b/docs/Components/ROS2/ROS2TopicList/index.md
@@ -24,11 +24,11 @@ To see how to custom messages type for ROS2, please refer to [Add custom ROS2 me
 
 
 ## Subscriber list
-|category|topic|msg|frame_id|hz|QoS|
-|:--|:--|:--|:--|:--|:--|
-|control|`/control/command/turn_indicators_cmd`|`autoware_auto_vehicle_msgs/TurnIndicatorsCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
-|control|`/control/command/hazard_lights_cmd`|`autoware_auto_vehicle_msgs/HazardLightsCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
-|control|`/control/command/control_cmd`|`autoware_auto_control_msgs/AckermannControlCommand`|none|`60`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
-|control|`/control/command/gear_cmd`|`autoware_auto_vehicle_msgs/GearCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
-|control|`/control/command/emergency_cmd`|`tier4_vehicle_msgs/msg/VehicleEmergencyStamped`|none|`60`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
+|category| topic                                  |msg|frame_id|hz|QoS|
+|:--|:---------------------------------------|:--|:--|:--|:--|
+|control| `/control/command/turn_indicators_cmd` |`autoware_auto_vehicle_msgs/TurnIndicatorsCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
+|control| `/control/command/hazard_lights_cmd`   |`autoware_auto_vehicle_msgs/HazardLightsCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
+|control| `/control/command/control_cmd_auto`    |`autoware_auto_control_msgs/AckermannControlCommand`|none|`60`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
+|control| `/control/command/gear_cmd`            |`autoware_auto_vehicle_msgs/GearCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
+|control| `/control/command/emergency_cmd`       |`tier4_vehicle_msgs/msg/VehicleEmergencyStamped`|none|`60`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
 

--- a/docs/Components/Vehicle/AWSIMVehicle/index.md
+++ b/docs/Components/Vehicle/AWSIMVehicle/index.md
@@ -88,10 +88,10 @@ The following section describes the API of `Vehicle.cs` script.
 
 `VehicleRosInput` subscribes to these topics and applies them to the Vehicle
 
-|topic|msg|frame_id|hz|QoS|
-|:--|:--|:--|:--|:--|
-|`/control/command/turn_indicators_cmd`|`autoware_auto_vehicle_msgs/TurnIndicatorsCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
-|`/control/command/hazard_lights_cmd`|`autoware_auto_vehicle_msgs/HazardLightsCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
-|`/control/command/control_cmd`|`autoware_auto_control_msgs/AckermannControlCommand`|none|`60`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
-|`/control/command/gear_cmd`|`autoware_auto_vehicle_msgs/GearCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
-|`/control/command/emergency_cmd`|`tier4_vehicle_msgs/msg/VehicleEmergencyStamped`|none|`60`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
+| topic                                  |msg|frame_id|hz|QoS|
+|:---------------------------------------|:--|:--|:--|:--|
+| `/control/command/turn_indicators_cmd` |`autoware_auto_vehicle_msgs/TurnIndicatorsCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
+| `/control/command/hazard_lights_cmd`   |`autoware_auto_vehicle_msgs/HazardLightsCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
+| `/control/command/control_cmd_auto`    |`autoware_auto_control_msgs/AckermannControlCommand`|none|`60`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
+| `/control/command/gear_cmd`            |`autoware_auto_vehicle_msgs/GearCommand`|none|`10`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|
+| `/control/command/emergency_cmd`       |`tier4_vehicle_msgs/msg/VehicleEmergencyStamped`|none|`60`|`Reliable`,<br> `TransientLocal`,<br> `KeepLast/1`|


### PR DESCRIPTION
## Link to the issue

Part of: https://github.com/autowarefoundation/autoware.universe/issues/3674

## Description

- https://github.com/autowarefoundation/autoware.universe/issues/3845 is merged.

Using this,

Autoware will publish:

| Topic                                   | Message Type             |
| --------------------------------------- | ------------------------ |
| `/control/command/control_cmd`          | `autoware_msgs`          |
| `/control/command/control_cmd_auto`     | `autoware_auto_msgs`     |

To enable compatibility, this PR renames the incoming topic to suffix `_auto`.

## How to review this PR

## Others
