### PR TITLE
Performance increase for RGLUnityPlugin by reducing garbage collection

### DIFF
--- a/Assets/RGLUnityPlugin/Scripts/SceneManager.cs
+++ b/Assets/RGLUnityPlugin/Scripts/SceneManager.cs
@@ -138,9 +138,8 @@ namespace RGLUnityPlugin
             SynchronizeSceneTime();
 
             Profiler.BeginSample("Find changes and make TODO list");
-            var thisFrameGOs = FindObjectsOfType<GameObject>()
-                .Where(go => go.activeInHierarchy)
-                .Where(go => go.GetComponentsInParent<LidarSensor>().Length == 0);
+            var thisFrameGOs = new HashSet<GameObject>(FindObjectsOfType<GameObject>());
+            thisFrameGOs.RemoveWhere(IsNotActiveOrParentHasLidar);
 
             // Added
             var toAddGOs = new HashSet<GameObject>(thisFrameGOs);
@@ -160,7 +159,7 @@ namespace RGLUnityPlugin
                 .Except(toRemove).ToArray();
             RGLObject[] toSkin = existingToSkin.Concat(newToSkin).ToArray();
 
-            lastFrameGameObjects = new HashSet<GameObject>(thisFrameGOs);
+            lastFrameGameObjects = thisFrameGOs;
             Profiler.EndSample();
 
             Profiler.BeginSample("Add new textures");
@@ -547,6 +546,11 @@ namespace RGLUnityPlugin
                 rglObject.SetIntensityTexture(sharedTextures[textureID]);
                 sharedTexturesUsageCount[textureID] += 1;
             }
+        }
+        
+        private static bool IsNotActiveOrParentHasLidar(GameObject gameObject)
+        {
+            return !gameObject.activeInHierarchy || gameObject.GetComponentsInParent<LidarSensor>().Length != 0;
         }
     }
 }


### PR DESCRIPTION
Removed LINQ and lambdas from initialization of thisFrameGOs variable. Performance tested on AWSIM/Scenes/Samples/LidarSkinnedStress scene since it provides a stable number of entities. The performance of the "Find changes and make TODO list" profiler section improved drastically from taking 21 ms to 9 ms on my machine:

Lenovo Legion Laptop
Processor: 1x 10th Generation Intel® Core™ i7-10750H Processor(Core™ i7-10750H)
Graphics: 1x NVIDIA®GeForce RTX™2070 SUPER™

I tried removing LINQ and lambdas from all other parts of SceneManager.cs, but this offered no noticeable performance improvements, so I decided to keep the old code for readability reasons.