### PR TITLE
chore: disable startup hdrp pop up in editor

### DIFF
--- a/ProjectSettings/HDRPProjectSettings.asset
+++ b/ProjectSettings/HDRPProjectSettings.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   version: 1
   m_ProjectSettingFolderPath: HDRPDefaultResources
-  m_WizardPopupAtStart: 1
+  m_WizardPopupAtStart: 0
   m_WizardPopupAlreadyShownOnce: 0
   m_WizardActiveTab: 2
   m_WizardNeedRestartAfterChangingToDX12: 0


### PR DESCRIPTION
This PR disables this window from popping up everytime the Unity Editor is opened.
![Screenshot from 2023-09-12 14-37-46](https://github.com/tier4/AWSIM/assets/10751153/14d6588c-b39a-46a4-84f6-fa4e9904b0b9)