### PR TITLE
feat: remove traffic on ctrl+x

### DIFF
--- a/Assets/AWSIM/Scripts/RandomTraffic/TrafficManager.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/TrafficManager.cs
@@ -187,6 +187,21 @@ public class TrafficManager : MonoBehaviour
         spawnLanes.Clear();
         npcVehicleSimulator.StepOnce(Time.fixedDeltaTime);
 
+        if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+        {
+            // Check if the X key was just pressed
+            if (Input.GetKeyDown(KeyCode.X))
+            {
+                // Set all vehicles to despawn
+                Debug.Log("Ctrl + X was pressed.");
+
+                foreach (var state in npcVehicleSimulator.VehicleStates)
+                {
+                    state.ShouldDespawn = true;
+                }
+            }
+        }
+
         Despawn();
     }
     private void Despawn()


### PR DESCRIPTION
This simple PR allows users to remove all traffic upon `CTRL+X` keypress.

It is very useful when you get traffic jams in AWSIM.

After this is executed, the vehicles keep spawning normally.

Example traffic jam: https://github.com/orgs/autowarefoundation/discussions/3813#discussioncomment-6924177

Feel free to change the hotkey as you like before merging.