### PR TITLE
feat: position reset with F5, F6, F7

### DIFF
--- a/Assets/AWSIM/Scripts/Vehicles/VehicleKeyboardInput.cs
+++ b/Assets/AWSIM/Scripts/Vehicles/VehicleKeyboardInput.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -27,6 +28,27 @@ namespace AWSIM
 
         [SerializeField] float maxAcceleration = 1.5f;
         [SerializeField] float maxSteerAngle = 35;
+
+        struct MyTransform
+        {
+            public Vector3 position;
+            public Quaternion rotation;
+        }
+        
+        private MyTransform originalTransform;
+        private MyTransform savedTransform;
+
+        private void Start()
+        {
+            if (vehicle == null)
+                vehicle = GetComponent<Vehicle>();
+            originalTransform = new MyTransform();
+            originalTransform.position = vehicle.transform.position;
+            originalTransform.rotation = vehicle.transform.rotation;
+            savedTransform = new MyTransform();
+            savedTransform.position = vehicle.transform.position;
+            savedTransform.rotation = vehicle.transform.rotation;
+        }
 
         void Reset()
         {
@@ -65,6 +87,26 @@ namespace AWSIM
                 vehicle.SignalInput = Vehicle.TurnSignal.HAZARD;
             else if (Input.GetKey(KeyCode.Alpha4))
                 vehicle.SignalInput = Vehicle.TurnSignal.NONE;
+
+            // Save the current transform when F7 is pressed
+            if (Input.GetKeyDown(KeyCode.F7))
+            {
+                savedTransform.position = vehicle.transform.position;
+                savedTransform.rotation = vehicle.transform.rotation;
+            }
+
+            // Set the vehicle's transform to the saved transform when F5 is pressed
+            if (Input.GetKeyDown(KeyCode.F5))
+            {
+                vehicle.transform.position = originalTransform.position;
+                vehicle.transform.rotation = originalTransform.rotation;
+            }
+
+            if (Input.GetKeyDown(KeyCode.F6))
+            {
+                vehicle.transform.position = savedTransform.position;
+                vehicle.transform.rotation = savedTransform.rotation;
+            }
         }
     }
 }


### PR DESCRIPTION
When developers use AWSIM, they want to reset the vehicle's position without restarting the entire simulation. Or maybe save a position in runtime and load from that position.

This is a very simple addition to enable these features.

F5: reset to initial position. (from simulation start)
F6: load to saved position. (to F7 saved position)
F7: save the current position.

This feature only works when the vehicle is moving (even if it's very slowly.) If you have any ideas to improve, expand from this, feel free to edit my PR.