### PR TITLE
Wrap RGLObject into try-catch to avoid processing the same objects endlessly

### DIFF
--- a/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLMeshObject.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLMeshObject.cs
@@ -60,10 +60,6 @@ namespace RGLUnityPlugin
             this.identifier = identifier;
             RepresentedGO = representedGO;
             rglMesh = GetRGLMeshFrom(meshSource);
-            if (rglMesh == null)
-            {
-                throw new RGLException($"Could not create RGLMesh from gameobject '{representedGO.name}'.");
-            }
             UploadToRGL();
             SetIntensityTexture();
 
@@ -219,12 +215,10 @@ namespace RGLUnityPlugin
         protected override RGLMesh GetRGLMeshFrom(MeshRenderer meshRenderer)
         {
             var meshFilter = meshRenderer.GetComponent<MeshFilter>();
-            if (meshFilter.sharedMesh == null)
+            if (meshFilter == null || meshFilter.sharedMesh == null)
             {
-                Debug.LogWarning($"Shared mesh of {meshRenderer.gameObject.name} is null, skipping");
-                return null;
+                throw new RGLException($"Shared mesh of {meshRenderer.gameObject.name} is null");
             }
-
             return RGLMeshSharingManager.RegisterRGLMeshInstance(meshFilter.sharedMesh);
         }
 
@@ -255,6 +249,10 @@ namespace RGLUnityPlugin
 
         protected override RGLMesh GetRGLMeshFrom(SkinnedMeshRenderer skinnedMeshRenderer)
         {
+            if (skinnedMeshRenderer.sharedMesh == null)
+            {
+                throw new RGLException($"Shared mesh of {skinnedMeshRenderer.gameObject} is null");
+            }
             // Skinned meshes cannot be shared by using RGLMeshSharingManager
             return new RGLSkinnedMesh(skinnedMeshRenderer.gameObject.GetInstanceID(), skinnedMeshRenderer);
         }

--- a/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLMeshObject.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLMeshObject.cs
@@ -185,7 +185,7 @@ namespace RGLUnityPlugin
             }
             catch (RGLException)
             {
-                Debug.LogError($"Cannot assign texture: {rglTexture.Texture.name}, to entity: {RepresentedGO.name}");
+                Debug.LogError($"Cannot assign texture: '{rglTexture.Texture.name}', to entity: '{RepresentedGO.name}'");
                 throw;
             }
 
@@ -217,7 +217,7 @@ namespace RGLUnityPlugin
             var meshFilter = meshRenderer.GetComponent<MeshFilter>();
             if (meshFilter == null || meshFilter.sharedMesh == null)
             {
-                throw new RGLException($"Shared mesh of {meshRenderer.gameObject.name} is null");
+                throw new RGLException($"Shared mesh of '{meshRenderer.gameObject.name}' is null");
             }
             return RGLMeshSharingManager.RegisterRGLMeshInstance(meshFilter.sharedMesh);
         }
@@ -251,7 +251,7 @@ namespace RGLUnityPlugin
         {
             if (skinnedMeshRenderer.sharedMesh == null)
             {
-                throw new RGLException($"Shared mesh of {skinnedMeshRenderer.gameObject} is null");
+                throw new RGLException($"Shared mesh of '{skinnedMeshRenderer.gameObject}' is null");
             }
             // Skinned meshes cannot be shared by using RGLMeshSharingManager
             return new RGLSkinnedMesh(skinnedMeshRenderer.gameObject.GetInstanceID(), skinnedMeshRenderer);

--- a/Assets/RGLUnityPlugin/Scripts/SceneManager.cs
+++ b/Assets/RGLUnityPlugin/Scripts/SceneManager.cs
@@ -268,7 +268,7 @@ namespace RGLUnityPlugin
                         continue;
                     }
 
-                    if (TryCreateRGLObject(collider, out IRGLObject rglObject))
+                    if (RGLObjectHelper.TryCreateRGLObject(collider, out IRGLObject rglObject))
                     {
                         yield return rglObject;
                     }
@@ -302,7 +302,7 @@ namespace RGLUnityPlugin
 
                 if (renderer is MeshRenderer mr)
                 {
-                    if (TryCreateRGLObject(renderer, out IRGLObject rglObject))
+                    if (RGLObjectHelper.TryCreateRGLObject(renderer, out IRGLObject rglObject))
                     {
                         yield return rglObject;
                     }
@@ -311,7 +311,7 @@ namespace RGLUnityPlugin
 
             foreach (var collider in collidersToYield)
             {
-                if (TryCreateRGLObject(collider, out IRGLObject rglObject))
+                if (RGLObjectHelper.TryCreateRGLObject(collider, out IRGLObject rglObject))
                 {
                     yield return rglObject;
                 }
@@ -327,7 +327,7 @@ namespace RGLUnityPlugin
         {
             foreach (var renderer in GetUniqueRenderersInGameObjects(gameObjects))
             {
-                if (TryCreateRGLObject(renderer, out IRGLObject rglObject))
+                if (RGLObjectHelper.TryCreateRGLObject(renderer, out IRGLObject rglObject))
                 {
                     yield return rglObject;
                 }
@@ -340,7 +340,7 @@ namespace RGLUnityPlugin
             {
                 if (gameObject.TryGetComponent<Terrain>(out var terrain))
                 {
-                    if (TryCreateRGLObject(terrain, out IRGLObject rglObject))
+                    if (RGLObjectHelper.TryCreateRGLObject(terrain, out IRGLObject rglObject))
                     {
                         yield return rglObject;
                     }
@@ -409,42 +409,6 @@ namespace RGLUnityPlugin
         private static bool IsNotActiveOrParentHasLidar(GameObject gameObject)
         {
             return !gameObject.activeInHierarchy || gameObject.GetComponentsInParent<LidarSensor>().Length != 0;
-        }
-
-        private static bool TryCreateRGLObject<T>(T meshSource, out IRGLObject rglObject) where T : UnityEngine.Object
-        {
-            try
-            {
-                if (meshSource is MeshRenderer mr)
-                {
-                    rglObject = new RGLMeshRendererObject(mr);
-                }
-                else if (meshSource is SkinnedMeshRenderer smr)
-                {
-                    rglObject = new RGLSkinnedMeshRendererObject(smr);
-                }
-                else if (meshSource is Collider collider)
-                {
-                    rglObject = new RGLColliderObject(collider);
-                }
-                else if (meshSource is Terrain terrain)
-                {
-                    rglObject = new RGLTerrainObject(terrain);
-                }
-                else
-                {
-                    Debug.LogError($"Could not create RGLObject from type '{typeof(T)}'");
-                    rglObject = null;
-                    return false;
-                }
-            }
-            catch (RGLException e)
-            {
-                Debug.LogWarning($"Cannot create RGLObject from '{meshSource.name}': {e.Message}. Skipping...");
-                rglObject = null;
-                return false;
-            }
-            return true;
         }
     }
 }

--- a/Assets/RGLUnityPlugin/Scripts/SceneManager.cs
+++ b/Assets/RGLUnityPlugin/Scripts/SceneManager.cs
@@ -268,7 +268,17 @@ namespace RGLUnityPlugin
                         continue;
                     }
 
-                    yield return new RGLColliderObject(collider);
+                    IRGLObject rglObject;
+                    try
+                    {
+                        rglObject = new RGLColliderObject(collider);
+                    }
+                    catch (RGLException e)
+                    {
+                        Debug.LogWarning($"Cannot create RGL object from '{collider.gameObject.name}': {e.Message}. Skipping...");
+                        continue;
+                    }
+                    yield return rglObject;
                 }
             }
         }
@@ -299,13 +309,33 @@ namespace RGLUnityPlugin
 
                 if (renderer is MeshRenderer mr)
                 {
-                    yield return new RGLMeshRendererObject(mr);
+                    IRGLObject rglObject;
+                    try
+                    {
+                        rglObject = new RGLMeshRendererObject(mr);
+                    }
+                    catch (RGLException e)
+                    {
+                        Debug.LogWarning($"Cannot create RGL object from '{mr.gameObject.name}': {e.Message}. Skipping...");
+                        continue;
+                    }
+                    yield return rglObject;
                 }
             }
 
             foreach (var collider in collidersToYield)
             {
-                yield return new RGLColliderObject(collider);
+                IRGLObject rglObject;
+                try
+                {
+                    rglObject = new RGLColliderObject(collider);
+                }
+                catch (RGLException e)
+                {
+                    Debug.LogWarning($"Cannot create RGL object from '{collider.gameObject.name}': {e.Message}. Skipping...");
+                    continue;
+                }
+                yield return rglObject;
             }
         }
 
@@ -320,18 +350,32 @@ namespace RGLUnityPlugin
             {
                 if (renderer is MeshRenderer mr)
                 {
-                    yield return new RGLMeshRendererObject(mr);
+                    IRGLObject rglObject;
+                    try
+                    {
+                        rglObject = new RGLMeshRendererObject(mr);
+                    }
+                    catch (RGLException e)
+                    {
+                        Debug.LogWarning($"Cannot create RGL object from '{mr.gameObject.name}': {e.Message}. Skipping...");
+                        continue;
+                    }
+                    yield return rglObject;
                 }
 
                 if (renderer is SkinnedMeshRenderer smr)
                 {
-                    if (smr.sharedMesh == null)
+                    IRGLObject rglObject;
+                    try
                     {
-                        Debug.LogWarning($"Shared mesh of {smr.gameObject} is null, skipping");
+                        rglObject = new RGLSkinnedMeshRendererObject(smr);
+                    }
+                    catch (RGLException e)
+                    {
+                        Debug.LogWarning($"Cannot create RGL object from '{smr.gameObject.name}': {e.Message}. Skipping...");
                         continue;
                     }
-
-                    yield return new RGLSkinnedMeshRendererObject(smr);
+                    yield return rglObject;
                 }
             }
         }
@@ -342,7 +386,17 @@ namespace RGLUnityPlugin
             {
                 if (gameObject.TryGetComponent<Terrain>(out var terrain))
                 {
-                    yield return new RGLTerrainObject(terrain);
+                    IRGLObject rglObject;
+                    try
+                    {
+                        rglObject = new RGLTerrainObject(terrain);
+                    }
+                    catch (RGLException e)
+                    {
+                        Debug.LogWarning($"Cannot create RGL object from '{terrain.gameObject.name}': {e.Message}. Skipping...");
+                        continue;
+                    }
+                    yield return rglObject;
                 }
             }
         }


### PR DESCRIPTION
In the [issue](https://github.com/tier4/AWSIM/issues/199), some of the game objects on the scene don't have mesh assigned to them, which prevents RGLObjects from being created on them (an exception is thrown in the constructor of RGLObject). It causes the current Update to abort and process the same objects on the next Update (and this situation repeats indefinitely).

This PR wraps RGLObject creation into a try-catch block which skips game objects from which no RGLObject can be created.