### PR TITLE
Warn user if running RGLUnityPlugin with sourced ROS2

### DIFF
--- a/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNativeAPI.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNativeAPI.cs
@@ -151,8 +151,14 @@ namespace RGLUnityPlugin
         static RGLNativeAPI()
         {
             string ros2SourcedCodename = Environment.GetEnvironmentVariable("ROS_DISTRO");
-            string ros2BuildType = string.IsNullOrEmpty(ros2SourcedCodename) ? "standalone" : "sourced";
-            Debug.Log($"RGL uses {ros2BuildType} ROS version.");
+            bool isRos2Sourced = !string.IsNullOrEmpty(ros2SourcedCodename);
+            if (isRos2Sourced)
+            {
+                Debug.LogError(
+                    "You should not source ROS2 in 'RobotecGPULidar' standalone build. " +
+                    "RGLUnityPlugin might not work correctly."
+                );
+            }
 
             try
             {


### PR DESCRIPTION
The latest ROS2 release is not working with the RGL standalone build.
RGLUnityPlugin should be running without sourcing ROS2 (the same as Ros2ForUnity plugin).
This PR adds an error message if running RGLUnityPlugin with sourced ROS2.

Related issue: https://github.com/tier4/AWSIM/issues/187