### PR TITLE
ROS 2 docs - configuration policies

### DIFF
--- a/docs/GettingStarted/QuickStartDemo/index.md
+++ b/docs/GettingStarted/QuickStartDemo/index.md
@@ -33,18 +33,25 @@ Please make sure that your machine meets the following requirements in order to 
 ### Localhost settings
 
 The simulation is based on the appropriate network setting, which allows for trouble-free communication of the AWSIM simulation with the Autoware software.
-To apply required localhost settings please add the following lines to `~/.bashrc` file.
+To apply required localhost settings please add the following lines to `~/.bashrc` file:
 
 ``` bash
-export ROS_LOCALHOST_ONLY=1
-export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-
 if [ ! -e /tmp/cycloneDDS_configured ]; then
 	sudo sysctl -w net.core.rmem_max=2147483647
 	sudo ip link set lo multicast on
 	touch /tmp/cycloneDDS_configured
 fi
 ```
+
+and these lines to `~/.profile` **or in either of files:** `~/.bash_profile` *or* `~/.bash_login`:
+
+``` bash
+export ROS_LOCALHOST_ONLY=1
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+!!! warning
+    A system restart is required for these changes to work.
 
 ## Start the demo
 

--- a/docs/GettingStarted/QuickStartDemo/index.md
+++ b/docs/GettingStarted/QuickStartDemo/index.md
@@ -188,7 +188,7 @@ ros2 launch autoware_launch e2e_simulator.launch.xml vehicle_model:=sample_vehic
 ```
 ![](Image_2.png)
 
-## 5. Let's run the self-Driving simulation
+## Let's run the self-Driving simulation
 
 1. Launch AWSIM and Autoware according to the steps described earlier in this document.
 ![](Image_top.png)
@@ -219,7 +219,7 @@ ros2 topic pub /autoware/engage autoware_auto_vehicle_msgs/msg/Engage '{engage: 
 
 The self-driving simulation demo has been successfully launched!
 
-## 6. Troubleshooting
+## Troubleshooting
 
 In case of any problems with running the sample AWSIM binary with Autoware, start with checking our [Troubleshooting page](https://tier4.github.io/AWSIM/DeveloperGuide/TroubleShooting/) with the most common problems.
 

--- a/docs/GettingStarted/SetupUnityProject/index.md
+++ b/docs/GettingStarted/SetupUnityProject/index.md
@@ -16,6 +16,26 @@ This page is a tutorial for setting up a AWSIM Unity project.
     2. Prepare a desktop PC with Ubuntu 22.04 installed.
     2. Install [Nvidia drivers and Vulkan Graphics API](../QuickStartDemo/#running-the-awsim-simulation-demo).
     3. Install [git](https://git-scm.com/).
+    4. Set the ROS 2 middleware and the localhost only mode in `~/.profile` (or, in `~/.bash_profile` or `~/bash_login` if either of those exists) file:
+    ``` bash
+    export ROS_LOCALHOST_ONLY=1
+    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+    ```
+
+        !!! warning
+            A system restart is required for these changes to work.
+
+    4. Set the system optimizations by adding this code to the very bottom of your `~/.bashrc` file:
+    ``` bash
+    if [ ! -e /tmp/cycloneDDS_configured ]; then
+        sudo sysctl -w net.core.rmem_max=2147483647
+        sudo ip link set lo multicast on
+        touch /tmp/cycloneDDS_configured
+    fi
+    ```
+
+        !!! info
+            As a result, each time you run the terminal (`bash` prompt), your OS will be configured for the best ROS 2 performance. Make sure you open your terminal at least one before running any instance of AWSIM (or Editor running the AWSIM).
 
 === "Windows"
     1. Make sure your machine meets the [required hardware specifications](../QuickStartDemo/#pc-specs).
@@ -55,29 +75,53 @@ Follow the steps below to install Unity on your machine:
 
 ### Open AWSIM project
 
+
+
 To open the Unity AWSIM project in Unity Editor:
-1. Make sure you have the AWSIM repository cloned
-    ```
-    git clone git@github.com:tier4/AWSIM.git
-    ```
 
-2. Launch UnityHub.
-    ```
-    ./UnityHub.AppImage
-    ```
+=== "Using Unity Hub"
+    1. Make sure you have the AWSIM repository cloned
+        ```
+        git clone git@github.com:tier4/AWSIM.git
+        ```
 
-3. Open the project in UnityHub
+    2. Launch UnityHub.
+        ```
+        ./UnityHub.AppImage
+        ```
+
+        !!! info
+
+            If you are launching the Unity Hub from the Ubuntu applications menu (without the terminal), make sure that system optimizations are set. To be sure, run the terminal at least once before running the Unity Hub. This will apply the OS settings.
+
+    3. Open the project in UnityHub
     - Click the `Open` button
-![](image_6.png)
+    ![](image_6.png)
 
     - Navigate the directory where the AWSIM repository was cloned to
-![](image_7.png)
+    ![](image_7.png)
 
     - The project should be added to `Projects` tab in Unity Hub. To launch the project in Unity Editor simply click the `AWSIM` item
-![](image_8.png)
+    ![](image_8.png)
 
     - The project is now ready to use
-![](image_9.png)
+    ![](image_9.png)
+
+=== "Using Terminal"
+
+    1. Enter the AWSIM directory
+        ```
+        cd AWSIM
+        ```
+
+    2. If your Unity Editor is in default location, run the project using the editor command.
+        ```
+        ~/Unity/Hub/Editor/2021.1.7f1/Editor/Unity -projectPath .
+        ```
+
+        !!! info
+            If your Unity Editor is installed in different location, please adjust the path accordingly.
+
 
 !!! warning
 
@@ -87,6 +131,8 @@ To open the Unity AWSIM project in Unity Editor:
     `$ wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.13_amd64.deb`
     2. install  
     `sudo dpkg -i libssl1.0.0_1.0.2n-1ubuntu5.13_amd64.deb`
+
+
 
 ### Import external packages
 

--- a/docs/GettingStarted/SetupUnityProject/index.md
+++ b/docs/GettingStarted/SetupUnityProject/index.md
@@ -75,8 +75,6 @@ Follow the steps below to install Unity on your machine:
 
 ### Open AWSIM project
 
-
-
 To open the Unity AWSIM project in Unity Editor:
 
 === "Using Unity Hub"
@@ -122,7 +120,6 @@ To open the Unity AWSIM project in Unity Editor:
         !!! info
             If your Unity Editor is installed in different location, please adjust the path accordingly.
 
-
 !!! warning
 
     If you get the safe mode dialog when starting UnityEditor, you may need to install openssl.
@@ -131,8 +128,6 @@ To open the Unity AWSIM project in Unity Editor:
     `$ wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.13_amd64.deb`
     2. install  
     `sudo dpkg -i libssl1.0.0_1.0.2n-1ubuntu5.13_amd64.deb`
-
-
 
 ### Import external packages
 


### PR DESCRIPTION
Reworked the localhost settings instructions to be more flexible:
- settings are now split into two files, which will resolve the issues when the user runs the AWSIM with the UnityHub **without the use of a terminal**
- added description how to run with terminal, without the use of UnityHub

Few more descriptions and infos.