### PR TITLE
Added LightOn Shader Properties to Traffic Light

### DIFF
--- a/Assets/AWSIM/Scripts/Environments/TrafficLight.cs
+++ b/Assets/AWSIM/Scripts/Environments/TrafficLight.cs
@@ -105,6 +105,7 @@ namespace AWSIM
             const string EmissiveColor = "_EmissiveColor";
             const string EmissiveIntensity = "_EmissiveIntensity";
             const string EmissiveExposureWeight = "_EmissiveExposureWeight";
+            const string LightOnFlag = "_LightOn";
             const float flashIntervalSec = 0.5f;                // flash bulb lighting interval(sec).
 
             float timer = 0;                            // used for flashing status.     NOTE: Might as well make it static and refer to the same time. 
@@ -210,6 +211,10 @@ namespace AWSIM
                     var config = bulbColorConfigPairs[color];
                     material.SetColor(EmissiveColor, config.Color * config.Intensity);
                     material.SetFloat(EmissiveExposureWeight, config.ExposureWeight);
+                    if(material.HasProperty(LightOnFlag))
+                    {
+                        material.SetInt(LightOnFlag, 1);
+                    }
                     this.isLightOn = true;
                     timer = 0;
                 }
@@ -217,6 +222,10 @@ namespace AWSIM
                 {
                     material.SetColor(EmissiveColor, defaultEmissiveColor);
                     material.SetFloat(EmissiveExposureWeight, defaultEmissiveExposureWeight);
+                    if(material.HasProperty(LightOnFlag))
+                    {
+                        material.SetInt(LightOnFlag, 0);
+                    }
                     this.isLightOn = false;
                     timer = 0;
                 }


### PR DESCRIPTION
This feature allows more customisation of the traffic light shaders. For example, in the case of traffic lights constructed in such a way, that there is a single bulb for red and green. And, to create a digital twin of such a construction in AWSIM, a custom shader has to be designed.

The changes include:
- introduceing the new shader parameter in the `TrafficLight.cs` script: _**"_LightOn"**_
- setting the value of this parameter when the light bulb state changes,

This allows to move the critical implementation of the light behaviour to be moved to the shader instead of implementing it in `TrafficLight.cs.`