### PR TITLE
Integrate energy loss feature to lidar snow

### DIFF
--- a/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
@@ -140,7 +140,7 @@ namespace RGLUnityPlugin
             if (LidarSnowManager.Instance != null)
             {
                 // Add deactivated node with some initial values. To be activated and updated when validating.
-                rglGraphLidar.AddNodePointsSimulateSnow(snowNodeId, 0.0f, 1.0f, 0.0001f, 0.0001f, 0.2f, 0.01f, 1, 0.01f, false);
+                rglGraphLidar.AddNodePointsSimulateSnow(snowNodeId, 0.0f, 1.0f, 0.0001f, 0.0001f, 0.2f, 0.01f, 1, 0.01f, false, 0.0f);
                 rglGraphLidar.SetActive(snowNodeId, false);
                 LidarSnowManager.Instance.OnNewConfig += OnValidate;
             }
@@ -203,7 +203,8 @@ namespace RGLUnityPlugin
                         LidarSnowManager.Instance.Density,
                         newConfig.laserArray.GetLaserRingIds().Length,
                         newConfig.beamDivergence * Mathf.Deg2Rad,
-                        LidarSnowManager.Instance.DoSimulateEnergyLoss);
+                        LidarSnowManager.Instance.DoSimulateEnergyLoss,
+                        LidarSnowManager.Instance.SnowflakeOccupancyThreshold);
                 }
                 rglGraphLidar.SetActive(snowNodeId, LidarSnowManager.Instance.IsSnowEnabled);
             }

--- a/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
@@ -140,7 +140,7 @@ namespace RGLUnityPlugin
             if (LidarSnowManager.Instance != null)
             {
                 // Add deactivated node with some initial values. To be activated and updated when validating.
-                rglGraphLidar.AddNodePointsSimulateSnow(snowNodeId, 0.0f, 1.0f, 0.0001f, 0.0001f, 0.2f, 0.01f, 1, 0.01f);
+                rglGraphLidar.AddNodePointsSimulateSnow(snowNodeId, 0.0f, 1.0f, 0.0001f, 0.0001f, 0.2f, 0.01f, 1, 0.01f, false);
                 rglGraphLidar.SetActive(snowNodeId, false);
                 LidarSnowManager.Instance.OnNewConfig += OnValidate;
             }
@@ -202,7 +202,8 @@ namespace RGLUnityPlugin
                         LidarSnowManager.Instance.TerminalVelocity,
                         LidarSnowManager.Instance.Density,
                         newConfig.laserArray.GetLaserRingIds().Length,
-                        newConfig.beamDivergence * Mathf.Deg2Rad);
+                        newConfig.beamDivergence * Mathf.Deg2Rad,
+                        LidarSnowManager.Instance.DoSimulateEnergyLoss);
                 }
                 rglGraphLidar.SetActive(snowNodeId, LidarSnowManager.Instance.IsSnowEnabled);
             }

--- a/Assets/RGLUnityPlugin/Scripts/LidarSnowManager.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarSnowManager.cs
@@ -54,6 +54,11 @@ namespace RGLUnityPlugin
         [field: Tooltip("If true, a more sophisticated method is used, which takes into account the energy loss of the lidar beam when hitting snowflakes")]
         public bool DoSimulateEnergyLoss { get; private set; } = true;
 
+        [field: SerializeField]
+        [field: Tooltip("Minimal snowflake occupancy (in percent) of the ray beam to be included in energy loss calculation")]
+        [field: Range(0.0f, 1.0f)]
+        public float SnowflakeOccupancyThreshold { get; private set; } = 0.0f;
+
         public bool IsSnowEnabled { get; private set; } = false;
 
         private void Awake()

--- a/Assets/RGLUnityPlugin/Scripts/LidarSnowManager.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarSnowManager.cs
@@ -55,7 +55,7 @@ namespace RGLUnityPlugin
         public bool DoSimulateEnergyLoss { get; private set; } = true;
 
         [field: SerializeField]
-        [field: Tooltip("Minimal snowflake occupancy (in percent) of the ray beam to be included in energy loss calculation")]
+        [field: Tooltip("Minimal snowflake occupancy (in fraction of ray beam angle) included in energy loss calculation")]
         [field: Range(0.0f, 1.0f)]
         public float SnowflakeOccupancyThreshold { get; private set; } = 0.0f;
 

--- a/Assets/RGLUnityPlugin/Scripts/LidarSnowManager.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarSnowManager.cs
@@ -50,6 +50,10 @@ namespace RGLUnityPlugin
         [field: Range(0.01f, 0.2f)]
         public float Density { get; private set; } = 0.07f;
 
+        [field: SerializeField]
+        [field: Tooltip("If true, a more sophisticated method is used, which takes into account the energy loss of the lidar beam when hitting snowflakes")]
+        public bool DoSimulateEnergyLoss { get; private set; } = true;
+
         public bool IsSnowEnabled { get; private set; } = false;
 
         private void Awake()

--- a/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNativeAPI.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNativeAPI.cs
@@ -136,7 +136,8 @@ namespace RGLUnityPlugin
 
         [DllImport("RobotecGPULidar")]
         public static extern int rgl_node_points_simulate_snow(ref IntPtr node, float min_range, float max_range, float rain_rate,
-            float mean_snowflake_diameter, float terminal_velocity, float density, Int32 num_channels, float beam_divergence);
+            float mean_snowflake_diameter, float terminal_velocity, float density, Int32 num_channels, float beam_divergence,
+            bool simulate_energy_loss);
 
         [DllImport("RobotecGPULidar")]
         public static extern int rgl_graph_run(IntPtr node);
@@ -498,10 +499,11 @@ namespace RGLUnityPlugin
         }
 
         public static void NodePointsSimulateSnow(ref IntPtr node, float minRange, float maxRange, float rainRate,
-            float meanSnowflakeDiameter, float terminalVelocity, float density, Int32 numChannels, float beamDivergence)
+            float meanSnowflakeDiameter, float terminalVelocity, float density, Int32 numChannels, float beamDivergence,
+            bool doSimulateEnergyLoss)
         {
             CheckErr(rgl_node_points_simulate_snow(ref node, minRange, maxRange, rainRate,
-                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence));
+                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence, doSimulateEnergyLoss));
         }
 
         public static void GraphRun(IntPtr node)

--- a/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNativeAPI.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNativeAPI.cs
@@ -137,7 +137,7 @@ namespace RGLUnityPlugin
         [DllImport("RobotecGPULidar")]
         public static extern int rgl_node_points_simulate_snow(ref IntPtr node, float min_range, float max_range, float rain_rate,
             float mean_snowflake_diameter, float terminal_velocity, float density, Int32 num_channels, float beam_divergence,
-            bool simulate_energy_loss);
+            bool simulate_energy_loss, float snowflake_occupancy_threshold);
 
         [DllImport("RobotecGPULidar")]
         public static extern int rgl_graph_run(IntPtr node);
@@ -500,10 +500,10 @@ namespace RGLUnityPlugin
 
         public static void NodePointsSimulateSnow(ref IntPtr node, float minRange, float maxRange, float rainRate,
             float meanSnowflakeDiameter, float terminalVelocity, float density, Int32 numChannels, float beamDivergence,
-            bool doSimulateEnergyLoss)
+            bool doSimulateEnergyLoss, float snowflakeOccupancyThreshold)
         {
             CheckErr(rgl_node_points_simulate_snow(ref node, minRange, maxRange, rainRate,
-                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence, doSimulateEnergyLoss));
+                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence, doSimulateEnergyLoss, snowflakeOccupancyThreshold));
         }
 
         public static void GraphRun(IntPtr node)

--- a/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNodeSequence.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNodeSequence.cs
@@ -293,12 +293,13 @@ namespace RGLUnityPlugin
         }
 
         public RGLNodeSequence AddNodePointsSimulateSnow(string identifier, float minRange, float maxRange, float rainRate,
-            float meanSnowflakeDiameter, float terminalVelocity, float density, Int32 numChannels, float beamDivergence)
+            float meanSnowflakeDiameter, float terminalVelocity, float density, Int32 numChannels, float beamDivergence,
+            bool doSimulateEnergyLoss)
         {
             CheckNodeNotExist(identifier);
             RGLNodeHandle handle = new RGLNodeHandle();
             RGLNativeAPI.NodePointsSimulateSnow(ref handle.Node, minRange, maxRange, rainRate,
-                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence);
+                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence, doSimulateEnergyLoss);
             handle.Type = RGLNodeType.POINTS_SIMULATE_SNOW;
             handle.Identifier = identifier;
             AddNode(handle);
@@ -419,11 +420,12 @@ namespace RGLUnityPlugin
         }
 
         public RGLNodeSequence UpdateNodePointsSimulateSnow(string identifier, float minRange, float maxRange, float rainRate,
-            float meanSnowflakeDiameter, float terminalVelocity, float density, Int32 numChannels, float beamDivergence)
+            float meanSnowflakeDiameter, float terminalVelocity, float density, Int32 numChannels, float beamDivergence,
+            bool doSimulateEnergyLoss)
         {
             RGLNodeHandle handle = ValidateNode(identifier, RGLNodeType.POINTS_SIMULATE_SNOW);
             RGLNativeAPI.NodePointsSimulateSnow(ref handle.Node, minRange, maxRange, rainRate,
-                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence);
+                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence, doSimulateEnergyLoss);
             return this;
         }
 

--- a/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNodeSequence.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LowLevelWrappers/RGLNodeSequence.cs
@@ -294,12 +294,13 @@ namespace RGLUnityPlugin
 
         public RGLNodeSequence AddNodePointsSimulateSnow(string identifier, float minRange, float maxRange, float rainRate,
             float meanSnowflakeDiameter, float terminalVelocity, float density, Int32 numChannels, float beamDivergence,
-            bool doSimulateEnergyLoss)
+            bool doSimulateEnergyLoss, float snowflakeOccupancyThreshold)
         {
             CheckNodeNotExist(identifier);
             RGLNodeHandle handle = new RGLNodeHandle();
             RGLNativeAPI.NodePointsSimulateSnow(ref handle.Node, minRange, maxRange, rainRate,
-                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence, doSimulateEnergyLoss);
+                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence, doSimulateEnergyLoss,
+                snowflakeOccupancyThreshold);
             handle.Type = RGLNodeType.POINTS_SIMULATE_SNOW;
             handle.Identifier = identifier;
             AddNode(handle);
@@ -421,11 +422,12 @@ namespace RGLUnityPlugin
 
         public RGLNodeSequence UpdateNodePointsSimulateSnow(string identifier, float minRange, float maxRange, float rainRate,
             float meanSnowflakeDiameter, float terminalVelocity, float density, Int32 numChannels, float beamDivergence,
-            bool doSimulateEnergyLoss)
+            bool doSimulateEnergyLoss, float snowflakeOccupancyThreshold)
         {
             RGLNodeHandle handle = ValidateNode(identifier, RGLNodeType.POINTS_SIMULATE_SNOW);
             RGLNativeAPI.NodePointsSimulateSnow(ref handle.Node, minRange, maxRange, rainRate,
-                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence, doSimulateEnergyLoss);
+                meanSnowflakeDiameter, terminalVelocity, density, numChannels, beamDivergence, doSimulateEnergyLoss,
+                snowflakeOccupancyThreshold);
             return this;
         }
 


### PR DESCRIPTION
This PR provides interface extension to the snow simulation feature. It adds the following widgets:
- checkbox DoSimulateEnergyLoss - switches between snow simulation methods - if false, the algorithm takes into account only the closest snowflake in the ray beam. If true, it takes into account all snowflakes in the ray beam and computes energy loss.
- slider SnowflakeOccupancyThreshold - Allows to ignore snowflakes that are less than given fraction of ray beam, as if they were transparent.