### PR TITLE
fix: add warning if way id and relation id may be incorrectly assigned

### DIFF
--- a/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/LaneletLoader/LaneletLoader.cs
+++ b/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/LaneletLoader/LaneletLoader.cs
@@ -289,6 +289,7 @@ namespace AWSIM.TrafficSimulation
         private void AssignLaneletElementIdToTrafficSignalGameObjects()
         {
             TrafficLight[] trafficLights = GameObject.FindObjectsOfType<TrafficLight>();
+            Dictionary<string, List<long>> verifiedTrafficLights = new Dictionary<string, List<long>>();
             var regElems = laneletMap.RegulatoryElements.Values
                     .Where(regElem => regElem.Type == RegulatoryElementType.TRAFFIC_LIGHT);
 
@@ -303,6 +304,29 @@ namespace AWSIM.TrafficSimulation
                         continue;
                     }
                     FillTrafficLightRelationIDWayID(closestTrafficLight, regElem.ID, line.ID);
+                    if (verifiedTrafficLights.ContainsKey(closestTrafficLight.name))
+                    {
+                        if(!verifiedTrafficLights[closestTrafficLight.name].Contains(line.ID))
+                        {
+                            verifiedTrafficLights[closestTrafficLight.name].Add(line.ID);
+                        }
+                    } else {
+                        verifiedTrafficLights.Add(closestTrafficLight.name, new List<long>{line.ID});
+                    }
+
+                }
+            }
+
+            foreach(var entry in verifiedTrafficLights)
+            {
+                if(entry.Value.Count >= 2)
+                {
+                    string wayIDs = "";
+                    foreach ( var wayID in entry.Value)
+                    {
+                        wayIDs += $"{wayID}, ";
+                    }
+                    Debug.LogWarning($"Verify {entry.Key} manually because may include wrong WayID and RalationID. Possible Way IDs [{wayIDs}]");
                 }
             }
         }
@@ -317,7 +341,10 @@ namespace AWSIM.TrafficSimulation
                 trafficLight.gameObject.AddComponent<TrafficLightLaneletID>();
                 trafficLightLaneletID = trafficLight.GetComponentInParent<TrafficLightLaneletID>();
             }
-
+            if (trafficLightLaneletID.wayID != TrafficLightLaneletID.InitWayID && trafficLightLaneletID.wayID != wayID)
+            {
+                trafficLightLaneletID.relationID.Clear();
+            }
             if (!trafficLightLaneletID.relationID.Contains(relationId))
             {
                 trafficLightLaneletID.relationID.Add(relationId);

--- a/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/LaneletLoader/LaneletLoader.cs
+++ b/Assets/AWSIM/Scripts/Editor/RandomTraffic/Environments/LaneletLoader/LaneletLoader.cs
@@ -326,7 +326,7 @@ namespace AWSIM.TrafficSimulation
                     {
                         wayIDs += $"{wayID}, ";
                     }
-                    Debug.LogWarning($"Verify {entry.Key} manually because may include wrong WayID and RalationID. Possible Way IDs [{wayIDs}]");
+                    Debug.LogWarning($"Verify '{entry.Key}' manually because may include wrong WayID and RelationID. Possible Way IDs [{wayIDs}]");
                 }
             }
         }

--- a/Assets/AWSIM/Scripts/Environments/TrafficLightLaneletID.cs
+++ b/Assets/AWSIM/Scripts/Environments/TrafficLightLaneletID.cs
@@ -10,7 +10,8 @@ namespace AWSIM
     [RequireComponent(typeof(TrafficLight))]
     public class TrafficLightLaneletID : MonoBehaviour
     {
-        public long wayID = 0;
+        public const int InitWayID = 0;
+        public long wayID = InitWayID;
         public List<long> relationID = new List<long>();
     }
 }


### PR DESCRIPTION
Add warning if way id and relation id may be incorrectly assigned

Sample:
![image](https://github.com/tier4/AWSIM/assets/8416175/8c4ce458-c790-411c-8112-a787adb971e5)
