### PR TITLE
fix: fix assemblies

### DIFF
--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
@@ -104,12 +104,13 @@ MonoBehaviour:
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0
+  doValidateConfigurationOnStartup: 1
   configuration:
     id: 0
   references:
     version: 1
     00000000:
-      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: Assembly-CSharp}
+      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         _laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 37.7, z: 0}

--- a/Assets/AWSIM/Scripts/Editor/AWSIM.Editor.asmdef
+++ b/Assets/AWSIM/Scripts/Editor/AWSIM.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "AWSIM.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:6adb9a5fec9cc8c478d3d8da6e48fe3b"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/AWSIM/Scripts/Editor/AWSIM.Editor.asmdef.meta
+++ b/Assets/AWSIM/Scripts/Editor/AWSIM.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d44af7d2d02f860baa5d577353d44953
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scripts/Lanelet/Visualize/Editor/AWSIM.Editor.asmref
+++ b/Assets/AWSIM/Scripts/Lanelet/Visualize/Editor/AWSIM.Editor.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:d44af7d2d02f860baa5d577353d44953"
+}

--- a/Assets/AWSIM/Scripts/Lanelet/Visualize/Editor/AWSIM.Editor.asmref.meta
+++ b/Assets/AWSIM/Scripts/Lanelet/Visualize/Editor/AWSIM.Editor.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0fe5dbba4368714bca49071cf6a3d03d
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scripts/Vehicles/Editor/AWSIM.Editor.asmref
+++ b/Assets/AWSIM/Scripts/Vehicles/Editor/AWSIM.Editor.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:d44af7d2d02f860baa5d577353d44953"
+}

--- a/Assets/AWSIM/Scripts/Vehicles/Editor/AWSIM.Editor.asmref.meta
+++ b/Assets/AWSIM/Scripts/Vehicles/Editor/AWSIM.Editor.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2365c74c504b86d3586b5a5e3979fca5
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR provides two fixes:
- add assemblies for Editor folders. Right now on the `main` branch, the binary can't be built due to an issue with the assemblies. The PR resolves this issue.
- update velodyne vlp16 prefab. Right now on `main` the AWSIM does not work with Autoware. The PR resolves this issue. 