### PR TITLE
Update prefabs of the LiDARs after configuration interface changes

### DIFF
--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiAT128E2X.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiAT128E2X.prefab
@@ -283,12 +283,13 @@ MonoBehaviour:
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0
+  doValidateConfigurationOnStartup: 1
   configuration:
     id: 0
   references:
     version: 1
     00000000:
-      type: {class: HesaiAT128LidarConfiguration, ns: RGLUnityPlugin, asm: Assembly-CSharp}
+      type: {class: HesaiAT128LidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         _laserArray:
           centerOfMeasurementLinearOffsetMm: {x: -17.1, y: 24, z: 41.65}

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar128E4X.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar128E4X.prefab
@@ -186,12 +186,13 @@ MonoBehaviour:
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0
+  doValidateConfigurationOnStartup: 1
   configuration:
     id: 0
   references:
     version: 1
     00000000:
-      type: {class: HesaiPandar128E4XLidarConfiguration, ns: RGLUnityPlugin, asm: Assembly-CSharp}
+      type: {class: HesaiPandar128E4XLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         _laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 88.33, z: 0}

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar40P.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar40P.prefab
@@ -512,12 +512,13 @@ MonoBehaviour:
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0
+  doValidateConfigurationOnStartup: 1
   configuration:
     id: 0
   references:
     version: 1
     00000000:
-      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: Assembly-CSharp}
+      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         _laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 47.7, z: 0}

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarQT64.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarQT64.prefab
@@ -415,12 +415,13 @@ MonoBehaviour:
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0
+  doValidateConfigurationOnStartup: 1
   configuration:
     id: 0
   references:
     version: 1
     00000000:
-      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: Assembly-CSharp}
+      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         _laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 50.4, z: 0}

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarXT32.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarXT32.prefab
@@ -283,12 +283,13 @@ MonoBehaviour:
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0
+  doValidateConfigurationOnStartup: 1
   configuration:
     id: 0
   references:
     version: 1
     00000000:
-      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: Assembly-CSharp}
+      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         _laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 46.4, z: 0}

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiQT128C2X.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiQT128C2X.prefab
@@ -104,12 +104,13 @@ MonoBehaviour:
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0
+  doValidateConfigurationOnStartup: 1
   configuration:
     id: 0
   references:
     version: 1
     00000000:
-      type: {class: HesaiQT128C2XLidarConfiguration, ns: RGLUnityPlugin, asm: Assembly-CSharp}
+      type: {class: HesaiQT128C2XLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         _laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 58.2, z: 0}

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/OusterOS1-64.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/OusterOS1-64.prefab
@@ -103,12 +103,13 @@ MonoBehaviour:
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0
+  doValidateConfigurationOnStartup: 1
   configuration:
     id: 0
   references:
     version: 1
     00000000:
-      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: Assembly-CSharp}
+      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         _laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 36.18, z: 0}

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
@@ -104,12 +104,13 @@ MonoBehaviour:
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0
+  doValidateConfigurationOnStartup: 1
   configuration:
     id: 0
   references:
     version: 1
     00000000:
-      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: Assembly-CSharp}
+      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         _laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 37.7, z: 0}

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP32C.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP32C.prefab
@@ -104,12 +104,13 @@ MonoBehaviour:
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0
+  doValidateConfigurationOnStartup: 1
   configuration:
     id: 0
   references:
     version: 1
     00000000:
-      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: Assembly-CSharp}
+      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         _laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 37.34, z: 0}

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLS128.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLS128.prefab
@@ -512,12 +512,13 @@ MonoBehaviour:
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0
+  doValidateConfigurationOnStartup: 1
   configuration:
     id: 0
   references:
     version: 1
     00000000:
-      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: Assembly-CSharp}
+      type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         _laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 66.11, z: 0}


### PR DESCRIPTION
This PR fixes prefabs after introducing validation of the LiDAR configuration (https://github.com/tier4/AWSIM/pull/294)
The configuration interface has changed and old prefabs couldn't be loaded properly.