### PR TITLE
Regression tests for LiDAR and Radar

### DIFF
--- a/Assets/Tests/PlayMode/Sensors/SensorsTest.cs
+++ b/Assets/Tests/PlayMode/Sensors/SensorsTest.cs
@@ -118,8 +118,6 @@ public class SensorsTest
             Assert.IsNotEmpty(pointCloudMessages);
             Assert.AreEqual(pointCloudMessages.Count, (int)(testDuration * radarSensor.automaticCaptureHz));
         }
-
-        // TODO: Test RadarScan publishers (radar_msgs_assembly needed)
     }
 
     [UnityTest]

--- a/Assets/Tests/PlayMode/Sensors/SensorsTest.cs
+++ b/Assets/Tests/PlayMode/Sensors/SensorsTest.cs
@@ -31,8 +31,8 @@ public class SensorsTest
 
     // LiDAR
     RGLUnityPlugin.LidarSensor lidarSensor;
-    ROS2.ISubscription<sensor_msgs.msg.PointCloud2> lidarSubscription;
-    List<sensor_msgs.msg.PointCloud2> lidarMessages;
+    ROS2.ISubscription<sensor_msgs.msg.PointCloud2> pointCloudSubscription;
+    List<sensor_msgs.msg.PointCloud2> pointCloudMessages;
 
     // IMU
     ImuSensor imuSensor;
@@ -52,9 +52,6 @@ public class SensorsTest
         poseMessages = new List<geometry_msgs.msg.PoseStamped>();
         poseWithCovarianceMessages = new List<geometry_msgs.msg.PoseWithCovarianceStamped>();
 
-        //LiDAR
-        lidarMessages = new List<sensor_msgs.msg.PointCloud2>();
-
         //IMU
         imuMessages = new List<sensor_msgs.msg.Imu>();
     }
@@ -73,6 +70,46 @@ public class SensorsTest
         imuSensor = GameObject.FindObjectOfType<ImuSensor>();
 
         yield return null;
+    }
+
+    private void CreatePointCloud2Subscription(PointCloud2Publisher rglRosPublisher)
+    {
+        QoSSettings qosSettingsLidar = new QoSSettings()
+        {
+            ReliabilityPolicy = ROS2.ReliabilityPolicy.QOS_POLICY_RELIABILITY_BEST_EFFORT,
+            DurabilityPolicy = ROS2.DurabilityPolicy.QOS_POLICY_DURABILITY_VOLATILE,
+            HistoryPolicy = ROS2.HistoryPolicy.QOS_POLICY_HISTORY_KEEP_LAST,
+            Depth = 1,
+        };
+
+        pointCloudMessages = new List<sensor_msgs.msg.PointCloud2>(); // Clear messages
+        pointCloudSubscription?.Dispose(); // Dispose previous subscription
+        pointCloudSubscription = SimulatorROS2Node.CreateSubscription<sensor_msgs.msg.PointCloud2>(
+            rglRosPublisher.topic, msg =>
+            {
+                pointCloudMessages.Add(msg);
+            }, qosSettingsLidar.GetQoSProfile());
+    }
+
+    [UnityTest]
+    public IEnumerator LiDAR()
+    {
+        Assert.NotNull(lidarSensor);
+        RglLidarPublisher lidarRos2Publisher = lidarSensor.GetComponent<RglLidarPublisher>();
+
+        Assert.AreEqual((byte)lidarRos2Publisher.qos.reliabilityPolicy , (byte)ROS2.ReliabilityPolicy.QOS_POLICY_RELIABILITY_BEST_EFFORT);
+
+        Assert.NotZero(lidarRos2Publisher.pointCloud2Publishers.Count);
+
+        // Test all LiDAR PointCloud2 publishers
+        foreach (var publisher in lidarRos2Publisher.pointCloud2Publishers)
+        {
+            CreatePointCloud2Subscription(publisher);
+            yield return new WaitForSeconds(testDuration);
+
+            Assert.IsNotEmpty(pointCloudMessages);
+            Assert.AreEqual(pointCloudMessages.Count, (int)(testDuration * lidarSensor.AutomaticCaptureHz));
+        }
     }
 
     [UnityTest]

--- a/Assets/Tests/PlayMode/Sensors/SensorsTest.unity
+++ b/Assets/Tests/PlayMode/Sensors/SensorsTest.unity
@@ -171,6 +171,68 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &304703635 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+  m_PrefabInstance: {fileID: 547809219}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &547809219
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2005356745}
+    m_Modifications:
+    - target: {fileID: 3829000484750794456, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_Name
+      value: SmartmicroDRVEGRD169
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7202717521197378927, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2af2d97e44fa5ea01b418ea17b9847b5, type: 3}
 --- !u!1 &780626756
 GameObject:
   m_ObjectHideFlags: 0
@@ -426,6 +488,102 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7b7ea1674328b854b98bd5008b84bb44, type: 3}
+--- !u!1 &812897209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 812897213}
+  - component: {fileID: 812897212}
+  - component: {fileID: 812897211}
+  - component: {fileID: 812897210}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &812897210
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812897209}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &812897211
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812897209}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 257
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &812897212
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812897209}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &812897213
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812897209}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 35, y: 0, z: 0}
+  m_LocalScale: {x: 0.01, y: 5, z: 5}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1112612167
 GameObject:
   m_ObjectHideFlags: 0
@@ -1007,6 +1165,37 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2005356744
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2005356745}
+  m_Layer: 0
+  m_Name: Radar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2005356745
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005356744}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 30, y: 2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 304703635}
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &2130635138
 GameObject:
   m_ObjectHideFlags: 0

--- a/docs/ProjectGuide/Testing/index.md
+++ b/docs/ProjectGuide/Testing/index.md
@@ -67,6 +67,8 @@ In summary, `Edit Mode` tests are well-suited for **testing isolated code compon
 
   - `GNSS`: Using the ROS 2 interface - verified the number of generated messages based on the sensor frequency.
   - `IMU`: Using the ROS 2 interface - verified the number of generated messages based on the sensor frequency.
+  - `LiDAR`: Using the ROS 2 interface - verified the number of generated messages based on the sensor frequency.
+  - `Radar`: Using the ROS 2 interface - verified the number of generated messages based on the sensor frequency.
 
 **Traffic Test:**
 


### PR DESCRIPTION
This PR:
- restores the regression test for LiDAR (it was deleted due to compilation errors after refactoring `RglLidarPublisher` component)
- adds the regression test for Radar

The changes are identical as proposed in [this PR](https://github.com/tier4/AWSIM/pull/282) but I decided to close it due to non-trivial merging conflicts.