### PR TITLE
Support compressed image

### DIFF
--- a/Assets/AWSIM/Scripts/Sensors/Camera/CameraSensor.cs
+++ b/Assets/AWSIM/Scripts/Sensors/Camera/CameraSensor.cs
@@ -170,6 +170,9 @@ namespace AWSIM
 
         private int bytesPerPixel = 3;
 
+        [HideInInspector]
+        public bool flip_image = false;
+
         void Start()
         {
             if (cameraObject == null)
@@ -223,6 +226,7 @@ namespace AWSIM
             rosImageShader.SetTexture(rosShaderKernelIdx, "_InputTexture", distortedRenderTexture);
             rosImageShader.SetBuffer(rosShaderKernelIdx, "_RosImageBuffer", computeBuffer);
             rosImageShader.Dispatch(rosShaderKernelIdx, rosImageShaderGroupSizeX, 1, 1);
+            rosImageShader.SetBool("_flip_image", flip_image);
 
             // Get data from shader
             AsyncGPUReadback.Request(computeBuffer, OnGPUReadbackRequest);

--- a/Assets/AWSIM/Scripts/Sensors/Camera/CameraSensorHolder.cs
+++ b/Assets/AWSIM/Scripts/Sensors/Camera/CameraSensorHolder.cs
@@ -19,7 +19,7 @@ namespace AWSIM
         /// Data output hz.
         /// Sensor processing and callbacks are called in this hz.
         /// </summary>
-        [Range(0, 30)][SerializeField] private uint publishHz = 10;
+        [Range(0, 60)][SerializeField] private uint publishHz = 10;
 
         /// <summary>
         /// Rendering sequence type.

--- a/Assets/AWSIM/Scripts/Sensors/Camera/RosImageShader.compute
+++ b/Assets/AWSIM/Scripts/Sensors/Camera/RosImageShader.compute
@@ -10,6 +10,8 @@ RWStructuredBuffer<uint> _RosImageBuffer;
 uint _width;
 uint _height;
 
+bool _flip_image;
+
 #define BYTES_PER_PIXEL 3
 #define SIZE_OF_UINT 4
 
@@ -28,7 +30,16 @@ void RosImageShaderKernel (uint3 id : SV_DispatchThreadID)
     // Convert coordinates for use in ROS (bgr8).
     // write down for distortion texture
     // write to B,G,R
-    uint rosImageY = _height - 1 - textureY;
+    
+    uint rosImageY = 0;
+    if (_flip_image)
+    {
+        rosImageY = textureY;
+    }
+    else
+    {
+        rosImageY = _height - 1 - textureY;
+    }
     float3 color1 = _InputTexture[float2(textureX, rosImageY)].rgb;
 
     // check boundary conditions


### PR DESCRIPTION
This pull request includes the following changes:
- Adds an option to select compressed images when publishing camera images.
- Modifies the shader to prevent the image from flipping during compression.

With this PR, the publish rate will increase from around 10 FPS to nearly 30 FPS.

![image](https://github.com/tier4/AWSIM/assets/53041471/086e6662-9829-476a-a0c9-6a1b16a2afe4)
