### PR TITLE
fix: ScenarioSimylatorConnector prefab

### DIFF
--- a/Assets/AWSIM/Prefabs/ScenarioSimulatorConnector/ScenarioSimulatorConnector.prefab
+++ b/Assets/AWSIM/Prefabs/ScenarioSimulatorConnector/ScenarioSimulatorConnector.prefab
@@ -46,25 +46,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   serverResponseAdress: tcp://127.0.0.1:8080
-  timeSource: {fileID: 11400000, guid: c916e55696587e8ce9377e6ab9cf7dda, type: 2}
-  entityPrefabs:
-  - assetKey: lexus_rx450h
-    prefab: {fileID: 4981081891045692864, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
-  - assetKey: taxi
-    prefab: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
-  - assetKey: truck_2t
-    prefab: {fileID: 6850358619771218631, guid: 9bc315af95865dd4bbf4a8f716791609, type: 3}
-  - assetKey: hatchback
-    prefab: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
-  - assetKey: van
-    prefab: {fileID: 536101250511469494, guid: 433e715a84edbae418fe585f802f3918, type: 3}
-  - assetKey: small_car
-    prefab: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
-  - assetKey: human
-    prefab: {fileID: 500668027104458449, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
-  entitesRoot: {fileID: 8549670399454290794}
-  egoFollowCamera: {fileID: 0}
-  requestProcessor: {fileID: 2447834225210429337}
 --- !u!114 &2447834225210429337
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -77,7 +58,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1ef965dd8e3341c7481f6549d4344cf8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  timeSource: {fileID: 11400000, guid: c916e55696587e8ce9377e6ab9cf7dda, type: 2}
   entityPrefabs:
   - AssetKey: lexus_rx450h
     Prefab: {fileID: 4981081891045692864, guid: 164645b2d105b6b4ab4e3d2e7c65dab2, type: 3}
@@ -93,8 +73,13 @@ MonoBehaviour:
     Prefab: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
   - AssetKey: human
     Prefab: {fileID: 500668027104458449, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+  - AssetKey: sign_board
+    Prefab: {fileID: 1084864657961548143, guid: 5dee7e956fab89e4b8ed0e2ff4f1ccac, type: 3}
   entitesRoot: {fileID: 8549670399454290794}
   egoFollowCamera: {fileID: 0}
+  vehicleInformationUI: {fileID: 0}
+  stepExecution: 0
+  stepDurationInPercentage: 0.5
 --- !u!1 &2893593835581794864
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Missing `sign_board` causes the following issue
![Screenshot_20240606_152129](https://github.com/tier4/AWSIM/assets/8416175/66687c9c-0b0d-4ee6-98f6-942c141a18ec)



This PR fixes the issue by adding `sign_board` to entity prefab list
![image](https://github.com/tier4/AWSIM/assets/8416175/3d5416af-9d6e-4b99-970f-01ac703f340b)
