### PR TITLE
RGL object fetching reworked

### DIFF
--- a/Assets/AWSIM/Scenes/Samples/Profiling.meta
+++ b/Assets/AWSIM/Scenes/Samples/Profiling.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3e9aa79cd86ba6056851b5d278df4fa4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scenes/Samples/Profiling/Cars.prefab
+++ b/Assets/AWSIM/Scenes/Samples/Profiling/Cars.prefab
@@ -1,0 +1,9726 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &659069491938123010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 659069491938123009}
+  m_Layer: 0
+  m_Name: SmallCars
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &659069491938123009
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 659069491938123010}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 64.98129, y: -113.22351, z: -136.73515}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7356339404485906382}
+  - {fileID: 7356339403631569687}
+  - {fileID: 7356339404354884727}
+  - {fileID: 7356339404276359950}
+  - {fileID: 7356339403894718502}
+  - {fileID: 7356339402865002898}
+  - {fileID: 7356339402949871029}
+  - {fileID: 7356339403014391786}
+  - {fileID: 7356339402624906267}
+  - {fileID: 7356339404277423277}
+  - {fileID: 7356339402774906222}
+  - {fileID: 7356339404557836894}
+  - {fileID: 7356339402689867821}
+  - {fileID: 7356339403798190953}
+  - {fileID: 7356339402965678926}
+  - {fileID: 7356339403146239480}
+  - {fileID: 7356339403169736754}
+  - {fileID: 7356339402900411021}
+  - {fileID: 7356339404238416623}
+  - {fileID: 7356339404074317569}
+  - {fileID: 7356339402958332465}
+  - {fileID: 7356339403978794620}
+  - {fileID: 7356339402837657206}
+  - {fileID: 7356339403014053732}
+  - {fileID: 7356339404057083328}
+  - {fileID: 7356339403173284930}
+  m_Father: {fileID: 659069492658408796}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &659069492007558862
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 659069492007558861}
+  m_Layer: 0
+  m_Name: Taxis
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &659069492007558861
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 659069492007558862}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 76.65017, y: -86.14422, z: -124.155594}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4737625123827318091}
+  - {fileID: 4737625123151181332}
+  - {fileID: 4737625123674870282}
+  - {fileID: 4737625122201019016}
+  - {fileID: 4737625123035930433}
+  - {fileID: 4737625123186487523}
+  - {fileID: 4737625122603718742}
+  - {fileID: 4737625123295931961}
+  - {fileID: 4737625122694753245}
+  - {fileID: 4737625122312924097}
+  - {fileID: 4737625123723993227}
+  - {fileID: 4737625122638257336}
+  - {fileID: 4737625122203058534}
+  - {fileID: 4737625122614871634}
+  - {fileID: 4737625122058358718}
+  - {fileID: 4737625123334747076}
+  - {fileID: 4737625122706376600}
+  - {fileID: 4737625123165325823}
+  - {fileID: 4737625123706095447}
+  - {fileID: 4737625122015425028}
+  - {fileID: 4737625123827739303}
+  - {fileID: 4737625122984735180}
+  - {fileID: 4737625122113824878}
+  - {fileID: 4737625123156285178}
+  m_Father: {fileID: 659069492658408796}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &659069492092665369
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 659069492092665368}
+  m_Layer: 0
+  m_Name: Hatchbacks
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &659069492092665368
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 659069492092665369}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 39.72455, y: -94.891594, z: -103.413765}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1440237346349503710}
+  - {fileID: 1440237345384131603}
+  - {fileID: 1440237346720152958}
+  - {fileID: 1440237344926421537}
+  - {fileID: 1440237345437048429}
+  - {fileID: 1440237346019767324}
+  - {fileID: 1440237345088263681}
+  - {fileID: 1440237346188513266}
+  - {fileID: 1440237346479148976}
+  - {fileID: 1440237346480903098}
+  - {fileID: 1440237346610057104}
+  - {fileID: 1440237346190695490}
+  - {fileID: 1440237346049199844}
+  - {fileID: 1440237344861892411}
+  - {fileID: 1440237345242434433}
+  - {fileID: 1440237345112431859}
+  - {fileID: 1440237346494843610}
+  - {fileID: 1440237346709001098}
+  - {fileID: 1440237345394832294}
+  - {fileID: 1440237346176886822}
+  - {fileID: 1440237346100778779}
+  - {fileID: 1440237346016918660}
+  - {fileID: 1440237346045802266}
+  - {fileID: 1440237345838140779}
+  m_Father: {fileID: 659069492658408796}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &659069492658408797
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 659069492658408796}
+  m_Layer: 0
+  m_Name: Cars
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &659069492658408796
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 659069492658408797}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -21.982426, y: 10.597641, z: 8.105588}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 659069492092665368}
+  - {fileID: 659069491938123009}
+  - {fileID: 659069492007558861}
+  - {fileID: 659069493749064003}
+  - {fileID: 659069493593826871}
+  - {fileID: 659069492678635876}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &659069492678635877
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 659069492678635876}
+  m_Layer: 0
+  m_Name: Taxis
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &659069492678635876
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 659069492678635877}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 76.65017, y: -86.14422, z: -146.25533}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4737625121937168051}
+  - {fileID: 4737625121811000969}
+  - {fileID: 4737625122053579574}
+  - {fileID: 4737625122221161839}
+  - {fileID: 4737625122501401091}
+  - {fileID: 4737625122935322586}
+  - {fileID: 4737625122410362387}
+  - {fileID: 4737625123767048769}
+  - {fileID: 4737625122550931453}
+  - {fileID: 4737625123569197031}
+  - {fileID: 4737625122306183175}
+  - {fileID: 4737625123242452868}
+  - {fileID: 4737625122214278713}
+  - {fileID: 4737625122210785719}
+  - {fileID: 4737625122134033718}
+  - {fileID: 4737625121891695514}
+  - {fileID: 4737625123268245290}
+  - {fileID: 4737625122022254068}
+  - {fileID: 4737625122395540697}
+  - {fileID: 4737625123707254755}
+  - {fileID: 4737625122604808048}
+  - {fileID: 4737625121984443026}
+  - {fileID: 4737625122997357008}
+  - {fileID: 4737625123422772318}
+  m_Father: {fileID: 659069492658408796}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &659069493593826824
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 659069493593826871}
+  m_Layer: 0
+  m_Name: SmallCars
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &659069493593826871
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 659069493593826824}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 64.98129, y: -113.22351, z: -158.83488}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7356339404041683151}
+  - {fileID: 7356339403833976727}
+  - {fileID: 7356339404006211365}
+  - {fileID: 7356339402991137763}
+  - {fileID: 7356339404439161890}
+  - {fileID: 7356339403376414769}
+  - {fileID: 7356339402736323866}
+  - {fileID: 7356339404386413344}
+  - {fileID: 7356339403272517590}
+  - {fileID: 7356339403548951892}
+  - {fileID: 7356339403984989878}
+  - {fileID: 7356339404160529867}
+  - {fileID: 7356339403649298529}
+  - {fileID: 7356339403706426251}
+  - {fileID: 7356339403437311108}
+  - {fileID: 7356339404028155291}
+  - {fileID: 7356339404247172747}
+  - {fileID: 7356339403661106297}
+  - {fileID: 7356339403402577405}
+  - {fileID: 7356339403897021433}
+  - {fileID: 7356339402896940780}
+  - {fileID: 7356339403559291920}
+  - {fileID: 7356339404008818847}
+  - {fileID: 7356339403297320379}
+  - {fileID: 7356339403002669923}
+  - {fileID: 7356339402502565693}
+  m_Father: {fileID: 659069492658408796}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &659069493749064004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 659069493749064003}
+  m_Layer: 0
+  m_Name: Hatchbacks
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &659069493749064003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 659069493749064004}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 39.72455, y: -94.891594, z: -125.5135}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1440237345412188936}
+  - {fileID: 1440237345396295275}
+  - {fileID: 1440237345129628844}
+  - {fileID: 1440237345226854692}
+  - {fileID: 1440237345619129598}
+  - {fileID: 1440237346048739646}
+  - {fileID: 1440237344838283014}
+  - {fileID: 1440237345339099505}
+  - {fileID: 1440237345284777073}
+  - {fileID: 1440237345451757368}
+  - {fileID: 1440237344816007549}
+  - {fileID: 1440237344938283160}
+  - {fileID: 1440237346908949939}
+  - {fileID: 1440237345036015592}
+  - {fileID: 1440237346703034583}
+  - {fileID: 1440237345975505413}
+  - {fileID: 1440237346691372891}
+  - {fileID: 1440237345830409952}
+  - {fileID: 1440237345207326009}
+  - {fileID: 1440237345560693520}
+  - {fileID: 1440237345146602473}
+  - {fileID: 1440237345047309190}
+  - {fileID: 1440237346696611882}
+  - {fileID: 1440237346888142675}
+  m_Father: {fileID: 659069492658408796}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &659069491862169621
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.158867
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403833976727 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069491862169621}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069491864686051
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -20.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625121937168051 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069491864686051}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069491886762434
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -70.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625121984443026 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069491886762434}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069491901852014
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -41.981262
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345838140779 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069491901852014}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069491909325541
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -28.122984
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345830409952 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069491909325541}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069491923020116
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -67.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122015425028 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069491923020116}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069491949747876
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -72.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122022254068 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069491949747876}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069491951712358
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122053579574 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069491951712358}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069491960861931
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -37.211132
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403798190953 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069491960861931}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069491978507502
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -53.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122058358718 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069491978507502}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069491991197145
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625121811000969 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069491991197145}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492006693374
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -52.385925
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403978794620 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492006693374}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492013146420
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -31.867058
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403984989878 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492013146420}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492033876135
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -14.115925
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404006211365 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492033876135}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492036486941
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (22)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -54.82185
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404008818847 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492036486941}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492052447483
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.0270176
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345619129598 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492052447483}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492057132964
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403894718502 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492057132964}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492059171963
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -57.73
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403897021433 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492059171963}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492080304330
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -59.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625121891695514 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492080304330}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492119807551
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -26.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122221161839 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492119807551}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492124058514
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -52.385925
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403559291920 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492124058514}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492124462441
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -45.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122214278713 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492124462441}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492130444007
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -48.260002
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122210785719 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492130444007}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492178054933
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -30.712122
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345560693520 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492178054933}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492227338385
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -50.809998
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122312924097 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492227338385}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492234193751
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -56.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122306183175 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492234193751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492247710422
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -26.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403548951892 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492247710422}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492260761357
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 18.838743
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345412188936 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492260761357}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492271721481
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -37.211132
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403706426251 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492271721481}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492276322926
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 15.997881
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345396295275 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492276322926}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492276942755
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -33.552986
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345394832294 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492276942755}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492287187773
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.1012583
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345451757368 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492287187773}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492292481854
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (22)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -81.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122113824878 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492292481854}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492301838952
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.0270176
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345437048429 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492301838952}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492305354342
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -53.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122134033718 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492305354342}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492330849429
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.158867
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403631569687 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492330849429}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492332342644
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.4029827
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345339099505 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492332342644}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492348846051
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -39.647057
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403649298529 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492348846051}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492355860502
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 15.997881
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345384131603 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492355860502}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492360090619
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -49.86479
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403661106297 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492360090619}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492370676278
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -45.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122203058534 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492370676278}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492372863448
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -26.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122201019016 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492372863448}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492387053684
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.9421206
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345284777073 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492387053684}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492407943507
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -28.92
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122501401091 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492407943507}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492414866594
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -24.417057
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404386413344 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492414866594}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492461110445
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -39.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122550931453 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492461110445}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492464316732
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -33.552986
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345207326009 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492464316732}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492497297284
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -22.522121
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345242434433 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492497297284}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492507083526
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -34.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122603718742 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492507083526}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492508175392
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -64.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122604808048 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492508175392}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492513207585
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10.62788
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345226854692 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492513207585}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492517559285
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -14.115925
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404354884727 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492517559285}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492525230060
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -36.25126
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (22)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345146602473 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492525230060}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492541808809
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.468742
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345129628844 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492541808809}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492583077769
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -78.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122395540697 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492583077769}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492586261980
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -34.302982
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404557836894 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492586261980}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492601045920
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404439161890 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492601045920}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492601564483
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -34.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122410362387 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492601564483}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492627372278
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.68126
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345112431859 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492627372278}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492647755852
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.7229424
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404485906382 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492647755852}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492651405828
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.4378796
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345088263681 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492651405828}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492692750211
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -39.092125
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345047309190 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492692750211}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492704048109
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -17.15212
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345036015592 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492704048109}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492726913561
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -44.604115
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404028155291 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492726913561}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492734211229
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.672121
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237344938283160 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492734211229}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492740706125
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.7229424
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404041683151 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492740706125}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492745418276
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10.62788
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237344926421537 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492745418276}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492755804738
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (24)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -67.364075
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404057083328 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492755804738}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492773042307
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -57.73
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404074317569 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492773042307}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492797725954
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -48.260002
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122614871634 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492797725954}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492802921837
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -47.428867
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404238416623 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492802921837}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492810057704
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -42.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122638257336 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492810057704}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492810926910
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -17.15212
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237344861892411 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492810926910}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492811974921
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -60.165924
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404247172747 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492811974921}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492841655436
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404276359950 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492841655436}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492842484527
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -26.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404277423277 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492842484527}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492859779657
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -34.302982
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339404160529867 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492859779657}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492873993416
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -61.82
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122706376600 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492873993416}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492885958797
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -39.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122694753245 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492885958797}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492900530947
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.4378796
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237344838283014 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492900530947}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492922871160
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.831259
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237344816007549 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492922871160}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492930849622
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -41.981262
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346888142675 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492930849622}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492947158033
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -28.92
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123035930433 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069492947158033}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492950584044
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -31.867058
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402774906222 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492950584044}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492977346998
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -14.311258
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346908949939 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069492977346998}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069492999995311
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -39.647057
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402689867821 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069492999995311}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493045658264
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -21.981133
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402736323866 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493045658264}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493072875886
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -62.687057
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402896940780 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493072875886}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493075565839
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -49.86479
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402900411021 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493075565839}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493115022474
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -31.78
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122935322586 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493115022474}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493128868702
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -25.282122
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346691372891 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493128868702}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493147814388
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (22)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -54.82185
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402837657206 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493147814388}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493166020987
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.468742
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346720152958 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493166020987}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493168106140
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -70.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122984735180 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493168106140}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493174863376
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -17.024075
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402865002898 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493174863376}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493177431951
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -28.122984
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346709001098 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493177431951}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493184048338
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -22.522121
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346703034583 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493184048338}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493189087872
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (22)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -81.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625122997357008 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493189087872}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493190732847
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -44.82212
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (23)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346696611882 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493190732847}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493209066389
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.831259
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346610057104 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493209066389}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493214552255
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (25)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -69.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402502565693 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493214552255}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493223978345
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -37.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123295931961 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493223978345}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493254367380
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -59.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123334747076 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493254367380}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493332282794
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (23)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -75.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123156285178 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493332282794}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493335043396
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123151181332 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493335043396}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493337455513
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -29.345924
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402624906267 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493337455513}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493339404223
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.1012583
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346480903098 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493339404223}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493339777973
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.9421206
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346479148976 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493339777973}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493356532399
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -72.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123165325823 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493356532399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493369334707
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -31.78
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123186487523 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493369334707}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493391650527
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -25.282122
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346494843610 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493391650527}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493413772500
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -42.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123242452868 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493413772500}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493455285370
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -61.82
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123268245290 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493455285370}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493470671067
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 18.838743
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346349503710 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493470671067}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493472436793
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (23)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -65.122986
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403297320379 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493472436793}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493487764663
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -50.809998
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123569197031 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493487764663}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493582116948
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -29.345924
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403272517590 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493582116948}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493585578330
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123674870282 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493585578330}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493602469646
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (23)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -75.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123422772318 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493602469646}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493612464902
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -42.16819
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403437311108 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493612464902}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493686017971
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -17.024075
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403376414769 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493686017971}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493695674439
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.672121
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346190695490 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493695674439}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493697653751
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.4029827
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346188513266 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493697653751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493710654499
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -30.712122
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346176886822 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493710654499}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493712210559
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -47.428867
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403402577405 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493712210559}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493734781431
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -64.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123827739303 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493734781431}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493734876699
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -20.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123827318091 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493734876699}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493785588510
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -36.25126
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (22)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346100778779 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493785588510}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493796866615
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -21.981133
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402949871029 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493796866615}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493799424025
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.86788
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346019767324 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493799424025}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493802342529
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -39.092125
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346016918660 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493802342529}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493805067699
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -62.687057
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402958332465 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493805067699}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493812409548
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -42.16819
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402965678926 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493812409548}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493837294305
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -14.311258
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346049199844 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493837294305}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493837347937
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339402991137763 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493837347937}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493838409019
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.86788
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346048739646 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493838409019}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493841744671
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492092665368}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -44.82212
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (23)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237346045802266 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493841744671}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493848876257
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493593826871}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (24)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -67.364075
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403002669923 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493848876257}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493860552934
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (23)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -65.122986
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403014053732 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493860552934}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493861386344
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -24.417057
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403014391786 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493861386344}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493882021808
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -60.165924
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403169736754 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493882021808}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493885797312
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (25)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -69.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403173284930 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493885797312}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493886397619
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -67.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123707254755 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493886397619}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493889965063
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -78.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123706095447 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493889965063}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493903145947
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492007558861}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -56.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123723993227 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493903145947}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493911975424
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069493749064003}
+    m_Modifications:
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.68126
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.29395
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 86.40721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_Name
+      value: Hatchback (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+--- !u!4 &1440237345975505413 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1934784267107460101, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  m_PrefabInstance: {fileID: 659069493911975424}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493962965265
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069492678635876}
+    m_Modifications:
+    - target: {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_Name
+      value: Taxi (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -37.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75.54658
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 118.55356
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+--- !u!4 &4737625123767048769 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5231512353441078096, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
+  m_PrefabInstance: {fileID: 659069493962965265}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659069493992739450
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 659069491938123009}
+    m_Modifications:
+    - target: {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_Name
+      value: SmallCar (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -44.604115
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.62587
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 125.56222
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+--- !u!4 &7356339403146239480 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8012901545304018818, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
+  m_PrefabInstance: {fileID: 659069493992739450}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/AWSIM/Scenes/Samples/Profiling/Cars.prefab.meta
+++ b/Assets/AWSIM/Scenes/Samples/Profiling/Cars.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ea5446726471730b8b2194a14ba91f77
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scenes/Samples/Profiling/Humans.prefab
+++ b/Assets/AWSIM/Scenes/Samples/Profiling/Humans.prefab
@@ -1,0 +1,158 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2599475467600085389
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2599475467600085388}
+  m_Layer: 0
+  m_Name: Humans
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2599475467600085388
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2599475467600085389}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -21.96237, y: 10.3188505, z: 8.325475}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3002312627599749666}
+  - {fileID: 3002312628736690913}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &2599475466708721225
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2599475467600085388}
+    m_Modifications:
+    - target: {fileID: 500668027104458449, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_Name
+      value: humanElegant
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 17.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -10.3188505
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -22.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+--- !u!4 &3002312627599749666 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+  m_PrefabInstance: {fileID: 2599475466708721225}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2599475467853604490
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2599475467600085388}
+    m_Modifications:
+    - target: {fileID: 500668027104458449, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_Name
+      value: humanElegant
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.09
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -10.3188505
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -22.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+--- !u!4 &3002312628736690913 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 988938448964725867, guid: 27e8a3736efefa447b1f65b33b30908a, type: 3}
+  m_PrefabInstance: {fileID: 2599475467853604490}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/AWSIM/Scenes/Samples/Profiling/Humans.prefab.meta
+++ b/Assets/AWSIM/Scenes/Samples/Profiling/Humans.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 47ba2b344a786e74081b25330e44ef90
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scenes/Samples/ProfilingSoloLidar.unity
+++ b/Assets/AWSIM/Scenes/Samples/ProfilingSoloLidar.unity
@@ -1,0 +1,864 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &728953441
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 728953445}
+  - component: {fileID: 728953444}
+  - component: {fileID: 728953443}
+  - component: {fileID: 728953442}
+  m_Layer: 0
+  m_Name: Floor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &728953442
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 728953441}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &728953443
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 728953441}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 257
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &728953444
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 728953441}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &728953445
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 728953441}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.05, z: 0}
+  m_LocalScale: {x: 100, y: 0.1, z: 100}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &882760104
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7245255253604249416, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245255253604249416, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.496622
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245255253604249416, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245255253604249416, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -13.54239
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245255253604249416, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245255253604249416, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245255253604249416, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245255253604249416, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245255253604249416, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245255253604249416, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7245255253604249416, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8054549295106192882, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+      propertyPath: m_Name
+      value: VelodyneVLS128
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8d984c5e45c176ab088ad8f798eceff7, type: 3}
+--- !u!1 &1103788748
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1103788750}
+  - component: {fileID: 1103788749}
+  - component: {fileID: 1103788751}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1103788749
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1103788748}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 100000
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 2
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 1
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1103788750
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1103788748}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &1103788751
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1103788748}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a68c43fe1f2a47cfa234b5eeaa98012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 11
+  m_ObsoleteShadowResolutionTier: 1
+  m_ObsoleteUseShadowQualitySettings: 0
+  m_ObsoleteCustomShadowResolution: 512
+  m_ObsoleteContactShadows: 0
+  m_PointlightHDType: 0
+  m_SpotLightShape: 0
+  m_AreaLightShape: 0
+  m_Intensity: 100000
+  m_EnableSpotReflector: 1
+  m_LuxAtDistance: 1
+  m_InnerSpotPercent: 0
+  m_SpotIESCutoffPercent: 100
+  m_LightDimmer: 1
+  m_VolumetricDimmer: 1
+  m_LightUnit: 2
+  m_FadeDistance: 10000
+  m_VolumetricFadeDistance: 10000
+  m_AffectDiffuse: 1
+  m_AffectSpecular: 1
+  m_NonLightmappedOnly: 0
+  m_ShapeWidth: 0.5
+  m_ShapeHeight: 0.5
+  m_AspectRatio: 1
+  m_ShapeRadius: 0.025
+  m_SoftnessScale: 1
+  m_UseCustomSpotLightShadowCone: 0
+  m_CustomSpotLightShadowCone: 30
+  m_MaxSmoothness: 0.99
+  m_ApplyRangeAttenuation: 1
+  m_DisplayAreaLightEmissiveMesh: 0
+  m_AreaLightCookie: {fileID: 0}
+  m_IESPoint: {fileID: 0}
+  m_IESSpot: {fileID: 0}
+  m_IncludeForRayTracing: 1
+  m_AreaLightShadowCone: 120
+  m_UseScreenSpaceShadows: 0
+  m_InteractsWithSky: 1
+  m_AngularDiameter: 0.5
+  m_FlareSize: 2
+  m_FlareTint: {r: 1, g: 1, b: 1, a: 1}
+  m_FlareFalloff: 4
+  m_SurfaceTexture: {fileID: 0}
+  m_SurfaceTint: {r: 1, g: 1, b: 1, a: 1}
+  m_Distance: 1.5e+11
+  m_UseRayTracedShadows: 0
+  m_NumRayTracingSamples: 4
+  m_FilterTracedShadow: 1
+  m_FilterSizeTraced: 16
+  m_SunLightConeAngle: 0.5
+  m_LightShadowRadius: 0.5
+  m_SemiTransparentShadow: 0
+  m_ColorShadow: 1
+  m_DistanceBasedFiltering: 0
+  m_EvsmExponent: 15
+  m_EvsmLightLeakBias: 0
+  m_EvsmVarianceBias: 0.00001
+  m_EvsmBlurPasses: 0
+  m_LightlayersMask: 1
+  m_LinkShadowLayers: 1
+  m_ShadowNearPlane: 0.1
+  m_BlockerSampleCount: 24
+  m_FilterSampleCount: 16
+  m_MinFilterSize: 0.1
+  m_KernelSize: 5
+  m_LightAngle: 1
+  m_MaxDepthBias: 0.001
+  m_ShadowResolution:
+    m_Override: 512
+    m_UseOverride: 1
+    m_Level: 0
+  m_ShadowDimmer: 1
+  m_VolumetricShadowDimmer: 1
+  m_ShadowFadeDistance: 10000
+  m_UseContactShadow:
+    m_Override: 0
+    m_UseOverride: 1
+    m_Level: 0
+  m_RayTracedContactShadow: 0
+  m_ShadowTint: {r: 0, g: 0, b: 0, a: 1}
+  m_PenumbraTint: 0
+  m_NormalBias: 0.75
+  m_SlopeBias: 0.5
+  m_ShadowUpdateMode: 0
+  m_AlwaysDrawDynamicShadows: 0
+  m_UpdateShadowOnLightMovement: 0
+  m_CachedShadowTranslationThreshold: 0.01
+  m_CachedShadowAngularThreshold: 0.5
+  m_BarnDoorAngle: 90
+  m_BarnDoorLength: 0.05
+  m_preserveCachedShadow: 0
+  m_OnDemandShadowRenderOnPlacement: 1
+  m_ShadowCascadeRatios:
+  - 0.05
+  - 0.2
+  - 0.3
+  m_ShadowCascadeBorders:
+  - 0.2
+  - 0.2
+  - 0.2
+  - 0.2
+  m_ShadowAlgorithm: 0
+  m_ShadowVariant: 0
+  m_ShadowPrecision: 0
+  useOldInspector: 0
+  useVolumetric: 1
+  featuresFoldout: 1
+  showAdditionalSettings: 0
+  m_AreaLightEmissiveMeshShadowCastingMode: 0
+  m_AreaLightEmissiveMeshMotionVectorGenerationMode: 0
+  m_AreaLightEmissiveMeshLayer: -1
+--- !u!1 &1359363713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1359363717}
+  - component: {fileID: 1359363716}
+  - component: {fileID: 1359363715}
+  - component: {fileID: 1359363714}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1359363714
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359363713}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23c1ce4fb46143f46bc5cb5224c934f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 7
+  m_ObsoleteRenderingPath: 0
+  m_ObsoleteFrameSettings:
+    overrides: 0
+    enableShadow: 0
+    enableContactShadows: 0
+    enableShadowMask: 0
+    enableSSR: 0
+    enableSSAO: 0
+    enableSubsurfaceScattering: 0
+    enableTransmission: 0
+    enableAtmosphericScattering: 0
+    enableVolumetrics: 0
+    enableReprojectionForVolumetrics: 0
+    enableLightLayers: 0
+    enableExposureControl: 1
+    diffuseGlobalDimmer: 0
+    specularGlobalDimmer: 0
+    shaderLitMode: 0
+    enableDepthPrepassWithDeferredRendering: 0
+    enableTransparentPrepass: 0
+    enableMotionVectors: 0
+    enableObjectMotionVectors: 0
+    enableDecals: 0
+    enableRoughRefraction: 0
+    enableTransparentPostpass: 0
+    enableDistortion: 0
+    enablePostprocess: 0
+    enableOpaqueObjects: 0
+    enableTransparentObjects: 0
+    enableRealtimePlanarReflection: 0
+    enableMSAA: 0
+    enableAsyncCompute: 0
+    runLightListAsync: 0
+    runSSRAsync: 0
+    runSSAOAsync: 0
+    runContactShadowsAsync: 0
+    runVolumeVoxelizationAsync: 0
+    lightLoopSettings:
+      overrides: 0
+      enableDeferredTileAndCluster: 0
+      enableComputeLightEvaluation: 0
+      enableComputeLightVariants: 0
+      enableComputeMaterialVariants: 0
+      enableFptlForForwardOpaque: 0
+      enableBigTilePrepass: 0
+      isFptlEnabled: 0
+  clearColorMode: 0
+  backgroundColorHDR: {r: 0.025, g: 0.07, b: 0.19, a: 0}
+  clearDepth: 1
+  volumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  volumeAnchorOverride: {fileID: 0}
+  antialiasing: 0
+  SMAAQuality: 2
+  dithering: 0
+  stopNaNs: 0
+  taaSharpenStrength: 0.5
+  TAAQuality: 1
+  taaHistorySharpening: 0.35
+  taaAntiFlicker: 0.5
+  taaMotionVectorRejection: 0
+  taaAntiHistoryRinging: 0
+  physicalParameters:
+    m_Iso: 200
+    m_ShutterSpeed: 0.005
+    m_Aperture: 16
+    m_BladeCount: 5
+    m_Curvature: {x: 2, y: 11}
+    m_BarrelClipping: 0.25
+    m_Anamorphism: 0
+  flipYMode: 0
+  xrRendering: 1
+  fullscreenPassthrough: 0
+  allowDynamicResolution: 0
+  customRenderingSettings: 0
+  invertFaceCulling: 0
+  probeLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  hasPersistentHistory: 0
+  exposureTarget: {fileID: 0}
+  m_RenderingPathCustomFrameSettings:
+    bitDatas:
+      data1: 72198262773251917
+      data2: 13763000468760363032
+    lodBias: 1
+    lodBiasMode: 0
+    lodBiasQualityLevel: 0
+    maximumLODLevel: 0
+    maximumLODLevelMode: 0
+    maximumLODLevelQualityLevel: 0
+    sssQualityMode: 0
+    sssQualityLevel: 0
+    sssCustomSampleBudget: 20
+    materialQuality: 0
+  renderingPathCustomFrameSettingsOverrideMask:
+    mask:
+      data1: 0
+      data2: 0
+  defaultFrameSettings: 0
+--- !u!81 &1359363715
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359363713}
+  m_Enabled: 1
+--- !u!20 &1359363716
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359363713}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1359363717
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359363713}
+  m_LocalRotation: {x: -0.075532, y: -0.92290765, z: 0.23794067, w: -0.29312232}
+  m_LocalPosition: {x: -24.582706, y: 13.086557, z: 11.786018}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &2135770398
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7072217863731950089, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_Name
+      value: RGLSceneManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145055722486604488, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145055722486604488, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145055722486604488, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145055722486604488, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145055722486604488, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145055722486604488, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145055722486604488, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145055722486604488, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145055722486604488, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145055722486604488, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145055722486604488, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cc197478b1787bffa8b1b92eb7e455e7, type: 3}
+--- !u!1001 &659069492014061207
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 659069492658408796, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 659069492658408796, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -21.982426
+      objectReference: {fileID: 0}
+    - target: {fileID: 659069492658408796, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.597641
+      objectReference: {fileID: 0}
+    - target: {fileID: 659069492658408796, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.105588
+      objectReference: {fileID: 0}
+    - target: {fileID: 659069492658408796, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 659069492658408796, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 659069492658408796, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 659069492658408796, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 659069492658408796, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 659069492658408796, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 659069492658408796, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 659069492658408797, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+      propertyPath: m_Name
+      value: Cars
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ea5446726471730b8b2194a14ba91f77, type: 3}
+--- !u!1001 &2599475467971088935
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2599475467600085388, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2599475467600085388, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -21.96237
+      objectReference: {fileID: 0}
+    - target: {fileID: 2599475467600085388, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.3188505
+      objectReference: {fileID: 0}
+    - target: {fileID: 2599475467600085388, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.325475
+      objectReference: {fileID: 0}
+    - target: {fileID: 2599475467600085388, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2599475467600085388, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2599475467600085388, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2599475467600085388, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2599475467600085388, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2599475467600085388, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2599475467600085388, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2599475467600085389, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}
+      propertyPath: m_Name
+      value: Humans
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 47ba2b344a786e74081b25330e44ef90, type: 3}

--- a/Assets/AWSIM/Scenes/Samples/ProfilingSoloLidar.unity.meta
+++ b/Assets/AWSIM/Scenes/Samples/ProfilingSoloLidar.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c656a3be99dbc534e999097b87d0731e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scripts/NPCs/Pedestrians/NPCPedestrian.cs
+++ b/Assets/AWSIM/Scripts/NPCs/Pedestrians/NPCPedestrian.cs
@@ -31,6 +31,25 @@ namespace AWSIM
         private const string moveSpeedProperty = "moveSpeed";
         private const string rotateSpeedProperty = "rotateSpeed";
 
+        private RGLUnityPlugin.SceneManager sceneManager;
+
+        void Start()
+        {
+            sceneManager = FindObjectOfType<RGLUnityPlugin.SceneManager>();
+            foreach (Transform child in gameObject.GetComponentsInChildren<Transform>())
+            {
+                sceneManager.RegisterRGLObject(child.gameObject);
+            }
+        }
+
+        void OnDestroy()
+        {
+            foreach (Transform child in gameObject.GetComponentsInChildren<Transform>())
+            {
+                sceneManager.UnregisterRGLObject(child.gameObject);
+            }
+        }
+
         private void Update()
         {
             // Switch animation based on movement speed (m/s).

--- a/Assets/AWSIM/Scripts/NPCs/Vehicles/NPCVehicle.cs
+++ b/Assets/AWSIM/Scripts/NPCs/Vehicles/NPCVehicle.cs
@@ -199,6 +199,8 @@ namespace AWSIM
         public Transform RigidBodyTransform => rigidbody.transform;
         public Transform TrailerTransform => trailer?.transform;
 
+        RGLUnityPlugin.SceneManager sceneManager;
+
         // Start is called before the first frame update
         void Awake()
         {
@@ -211,6 +213,15 @@ namespace AWSIM
             rigidbody.centerOfMass = transform.InverseTransformPoint(centerOfMass.position);
             lastPosition = rigidbody.position;
             wheelbase = axleSettings.GetWheelBase();
+        }
+
+        void Start()
+        {
+            sceneManager = FindObjectOfType<RGLUnityPlugin.SceneManager>();
+            foreach (Transform child in gameObject.GetComponentsInChildren<Transform>())
+            {
+                sceneManager.RegisterRGLObject(child.gameObject);
+            }
         }
 
         // Update is called once per frame
@@ -342,6 +353,10 @@ namespace AWSIM
             leftTurnSignalLight.Destroy();
             rightTurnSignalLight.Destroy();
             brakeLight.Destroy();
+            foreach (Transform child in gameObject.GetComponentsInChildren<Transform>())
+            {
+                sceneManager.UnregisterRGLObject(child.gameObject);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The approach for the system looks as follows:
- Fetch all the scene objects on the initialization, only once,
- Each object spawned on the scene (vehicle or pedestrian) registers itself in the RGL SceneManager.
- Each object despawned from the scene (vehicle or pedestrian) unregisters itself in from the RGL SceneManager.

In a result, there are no frequent fetches of the whole level (`FindObjectsOfType`).

Requires #148 
