### PR TITLE
fix: update missing prefab in TrafficTest

### DIFF
--- a/Assets/Tests/PlayMode/Traffic/TrafficTest.unity
+++ b/Assets/Tests/PlayMode/Traffic/TrafficTest.unity
@@ -409,7 +409,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   prefabs:
   - {fileID: 714549001370495616, guid: d0094c5a0e9fb6148873c658dbc61a89, type: 3}
-  - {fileID: 6604874415271597525, guid: 7e772e9ad7eb79040be629d8d04542ab, type: 3}
+  - {fileID: 8132031447337391826, guid: 916253e0333ad74ed89f7369a1321568, type: 3}
   - {fileID: 3333523281254186578, guid: 589cf2e451adab34eb1332da5701195a, type: 3}
   - {fileID: 536101250511469494, guid: 433e715a84edbae418fe585f802f3918, type: 3}
   startLines:


### PR DESCRIPTION
Update missing prefab
From
![Screenshot_20240620_110307](https://github.com/tier4/AWSIM/assets/8416175/5a443a04-9ecf-413e-a0af-cfe2d82b59b0)
to
![Screenshot_20240620_110342](https://github.com/tier4/AWSIM/assets/8416175/1b2982fc-f242-4f25-bde3-2640440758a7)
