### PR TITLE
feat: NavSatFix publisher for GNSS simulation

### DIFF
--- a/Assets/AWSIM/Scripts/Environments/Environment.cs
+++ b/Assets/AWSIM/Scripts/Environments/Environment.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 namespace AWSIM
 {
+    using Geographic;
+
     /// <summary>
     /// The Environment class.
     /// A collection of environment-related functions and property.
@@ -15,7 +17,10 @@ namespace AWSIM
         Vector3 mgrsOffsetPosition;
 
         [SerializeField]
-        string mgrsGridZone;
+        string mgrsGridZone = "54SUE";
+
+        [SerializeField]
+        GeoCoordinate worldOriginGeoCoordinate = new GeoCoordinate(35.499810, 138.854828, 0);
 
         /// <summary>
         /// Reference point of MGRS coordinate system.
@@ -27,5 +32,7 @@ namespace AWSIM
         /// </summary>
         /// <see href="https://maps.gsi.go.jp/#9/35.499810/138.854828/&base=std&ls=std&disp=1&vs=c1g1j0h0k0l0u1t0z0r0s0m0f1"></see>
         public string MgrsGridZone => mgrsGridZone;
+
+        public GeoCoordinate WorldOriginGeoCoordinate => worldOriginGeoCoordinate;
     }
 }

--- a/Assets/AWSIM/Scripts/GeoCoordinate.meta
+++ b/Assets/AWSIM/Scripts/GeoCoordinate.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5ff5d5d636f368630a2a2b27aee32cb6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinate.cs
+++ b/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinate.cs
@@ -3,9 +3,9 @@ namespace AWSIM.Geographic
 [System.Serializable]
 public class GeoCoordinate
 {
-  public double Latitude;
-  public double Longitude;
-  public double Altitude;
+  public double Latitude { get; }
+  public double Longitude { get; }
+  public double Altitude { get; }
 
   public GeoCoordinate()
   {

--- a/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinate.cs
+++ b/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinate.cs
@@ -1,0 +1,24 @@
+namespace AWSIM.Geographic
+{
+[System.Serializable]
+public class GeoCoordinate
+{
+  public double Latitude;
+  public double Longitude;
+  public double Altitude;
+
+  public GeoCoordinate()
+  {
+    Latitude = 0;
+    Longitude = 0;
+    Altitude = 0;
+  }
+
+  public GeoCoordinate(double latitude, double longitude, double altitude)
+  {
+    Latitude = latitude;
+    Longitude = longitude;
+    Altitude = altitude;
+  }
+}
+}

--- a/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinate.cs
+++ b/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinate.cs
@@ -1,24 +1,24 @@
 namespace AWSIM.Geographic
 {
-[System.Serializable]
-public class GeoCoordinate
-{
-  public double Latitude { get; }
-  public double Longitude { get; }
-  public double Altitude { get; }
+    [System.Serializable]
+    public class GeoCoordinate
+    {
+        public double Latitude { get; }
+        public double Longitude { get; }
+        public double Altitude { get; }
 
-  public GeoCoordinate()
-  {
-    Latitude = 0;
-    Longitude = 0;
-    Altitude = 0;
-  }
+        public GeoCoordinate()
+        {
+            Latitude = 0;
+            Longitude = 0;
+            Altitude = 0;
+        }
 
-  public GeoCoordinate(double latitude, double longitude, double altitude)
-  {
-    Latitude = latitude;
-    Longitude = longitude;
-    Altitude = altitude;
-  }
-}
+        public GeoCoordinate(double latitude, double longitude, double altitude)
+        {
+            Latitude = latitude;
+            Longitude = longitude;
+            Altitude = altitude;
+        }
+    }
 }

--- a/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinate.cs.meta
+++ b/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42f7a85d1202c9ba68da005fc52aff78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinateConverter.cs
+++ b/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinateConverter.cs
@@ -3,6 +3,10 @@ using UnityEngine;
 
 namespace AWSIM.Geographic
 {
+/// <summary>
+/// Provide Vector3 to GeoCoordinate conversion.
+/// reference : https://vldb.gsi.go.jp/sokuchi/surveycalc/main.html
+/// </summary>
 public static class GeoCoordinateConverter
 {
   const double EARTH_SEMI_MAJOR_AXIS = 6378137d;  // [m]

--- a/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinateConverter.cs
+++ b/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinateConverter.cs
@@ -1,0 +1,98 @@
+using System;
+using UnityEngine;
+
+namespace AWSIM.Geographic
+{
+public static class GeoCoordinateConverter
+{
+  const double EARTH_SEMI_MAJOR_AXIS = 6378137d;  // [m]
+  const double FLATTENING_INV = 298.257222101d;
+  const double SCALE_FACTOR = 0.9999d;
+
+  const double n = 1d / (2d * FLATTENING_INV - 1d);
+  const double n2 = n * n;
+  const double n3 = n2 * n;
+  const double n4 = n3 * n;
+  const double n5 = n4 * n;
+  const double n6 = n5 * n;
+
+  static readonly double[] A = new double[6]
+  {
+    1 + n2 / 4 + n4 / 64,
+    -3d / 2d*(n - n3 / 8 - n5 / 64),
+    15d / 16d * (n2 - n4 / 4),
+    -35d / 48d * (n3 - 5d / 16d * n5),
+    315d / 512d * n4,
+    -693d / 1280d * n5
+  };
+  static readonly double A_b = SCALE_FACTOR * EARTH_SEMI_MAJOR_AXIS / (1 + n) * A[0];
+
+  static readonly double[] beta = new double[6]
+  {
+    0,
+    1d / 2d * n - 2d / 3d * n2 + 37d / 96d * n3 - 1d / 360d * n4 - 81d / 512d * n5,
+    1d / 48d * n2 + 1d / 15d * n3 - 437d / 1440d * n4 + 46d / 105d * n5,
+    17d / 480d * n3 - 37d / 840d * n4 - 209d / 4480d * n5,
+    4397d / 161280d * n4 - 11d / 504d * n5,
+    4583d / 161280d * n5
+  };
+
+  static readonly double[] delta = new double[7]
+  {
+    0,
+    2d * n - 2d / 3d * n2 - 2d * n3 + 116d / 45d * n4 + 26d / 45d * n5 - 2854d / 675d * n6,
+    7d / 3d * n2 - 8d / 5d * n3 - 227d / 45d * n4 + 2704d / 315d * n5 + 2323d / 945d * n6,
+    56d / 15d * n3 - 136d / 35d * n4 - 1262d / 105d * n5 + 73814d / 2835d * n6,
+    4279d / 630d * n4 - 332d / 35d * n5 - 399572d / 14175d * n6,
+    4174d / 315d * n5 - 144838d / 6237d * n6,
+    601676d / 22275d * n6
+  };
+
+  public static GeoCoordinate Cartesian2Geo(Vector3 cartesian, GeoCoordinate origin)
+  {
+    double latitude0 = Deg2Rad(origin.Latitude);
+    double longitude0 = Deg2Rad(origin.Longitude);
+
+    double S = A[0] * latitude0;
+    for(int i = 1; i <= 5; i++)
+    {
+      S += A[i] * Math.Sin(2 * i * latitude0);
+    }
+    S = S * (SCALE_FACTOR * EARTH_SEMI_MAJOR_AXIS) / (1 + n);
+
+    double xi = (cartesian.z + S) / A_b;
+    double eta = cartesian.x / (A_b);
+
+    double xi_d = xi;
+    double eta_d = eta;
+    double sigma_d = 1;
+    double tau_d = 0;
+    for(int i = 1; i <= 5; i++)
+    {
+      int i2 = 2 * i;
+      xi_d -= beta[i] * Math.Sin(i2 * xi) * Math.Cosh(i2 * eta);
+      eta_d -= beta[i] * Math.Cos(i2 * xi) * Math.Sinh(i2 * eta);
+      sigma_d -= beta[i] * Math.Cos(i2 * xi) * Math.Cosh(i2 * eta) * i2;
+      tau_d += beta[i] * Math.Sin(i2 * xi) * Math.Sinh(i2 * eta) * i2;
+    }
+
+    double chi = Math.Asin(Math.Sin(xi_d) / Math.Cosh(eta_d));
+
+    double latitude = chi;
+    for(int i = 1; i <= 6; i++)
+    {
+      latitude += delta[i] * Math.Sin(2 * i * chi);
+    }
+
+    return new GeoCoordinate()
+    {
+      Latitude = Rad2Deg(latitude),
+      Longitude = Rad2Deg(longitude0 + Math.Atan(Math.Sinh(eta_d) / Math.Cos(xi_d))),
+      Altitude = cartesian.y - origin.Altitude
+    };
+  }
+
+  private static double Deg2Rad(double deg) => deg * Math.PI / 180d;
+  private static double Rad2Deg(double rad) => rad * 180d / Math.PI;
+}
+}

--- a/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinateConverter.cs
+++ b/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinateConverter.cs
@@ -84,12 +84,11 @@ public static class GeoCoordinateConverter
       latitude += delta[i] * Math.Sin(2 * i * chi);
     }
 
-    return new GeoCoordinate()
-    {
-      Latitude = Rad2Deg(latitude),
-      Longitude = Rad2Deg(longitude0 + Math.Atan(Math.Sinh(eta_d) / Math.Cos(xi_d))),
-      Altitude = cartesian.y - origin.Altitude
-    };
+    return new GeoCoordinate(
+      Rad2Deg(latitude),
+      Rad2Deg(longitude0 + Math.Atan(Math.Sinh(eta_d) / Math.Cos(xi_d))),
+      cartesian.y - origin.Altitude
+    );
   }
 
   private static double Deg2Rad(double deg) => deg * Math.PI / 180d;

--- a/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinateConverter.cs
+++ b/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinateConverter.cs
@@ -3,99 +3,99 @@ using UnityEngine;
 
 namespace AWSIM.Geographic
 {
-/// <summary>
-/// Provide Vector3 to GeoCoordinate conversion.
-/// reference : https://vldb.gsi.go.jp/sokuchi/surveycalc/main.html
-/// </summary>
-public static class GeoCoordinateConverter
-{
-  const double EARTH_SEMI_MAJOR_AXIS = 6378137d;  // [m]
-  const double FLATTENING_INV = 298.257222101d;
-  const double SCALE_FACTOR = 0.9999d;
-
-  const double n = 1d / (2d * FLATTENING_INV - 1d);
-  const double n2 = n * n;
-  const double n3 = n2 * n;
-  const double n4 = n3 * n;
-  const double n5 = n4 * n;
-  const double n6 = n5 * n;
-
-  static readonly double[] A = new double[6]
-  {
-    1 + n2 / 4 + n4 / 64,
-    -3d / 2d*(n - n3 / 8 - n5 / 64),
-    15d / 16d * (n2 - n4 / 4),
-    -35d / 48d * (n3 - 5d / 16d * n5),
-    315d / 512d * n4,
-    -693d / 1280d * n5
-  };
-  static readonly double A_b = SCALE_FACTOR * EARTH_SEMI_MAJOR_AXIS / (1 + n) * A[0];
-
-  static readonly double[] beta = new double[6]
-  {
-    0,
-    1d / 2d * n - 2d / 3d * n2 + 37d / 96d * n3 - 1d / 360d * n4 - 81d / 512d * n5,
-    1d / 48d * n2 + 1d / 15d * n3 - 437d / 1440d * n4 + 46d / 105d * n5,
-    17d / 480d * n3 - 37d / 840d * n4 - 209d / 4480d * n5,
-    4397d / 161280d * n4 - 11d / 504d * n5,
-    4583d / 161280d * n5
-  };
-
-  static readonly double[] delta = new double[7]
-  {
-    0,
-    2d * n - 2d / 3d * n2 - 2d * n3 + 116d / 45d * n4 + 26d / 45d * n5 - 2854d / 675d * n6,
-    7d / 3d * n2 - 8d / 5d * n3 - 227d / 45d * n4 + 2704d / 315d * n5 + 2323d / 945d * n6,
-    56d / 15d * n3 - 136d / 35d * n4 - 1262d / 105d * n5 + 73814d / 2835d * n6,
-    4279d / 630d * n4 - 332d / 35d * n5 - 399572d / 14175d * n6,
-    4174d / 315d * n5 - 144838d / 6237d * n6,
-    601676d / 22275d * n6
-  };
-
-  public static GeoCoordinate Cartesian2Geo(Vector3 cartesian, GeoCoordinate origin)
-  {
-    double latitude0 = Deg2Rad(origin.Latitude);
-    double longitude0 = Deg2Rad(origin.Longitude);
-
-    double S = A[0] * latitude0;
-    for(int i = 1; i <= 5; i++)
+    /// <summary>
+    /// Provide Vector3 to GeoCoordinate conversion.
+    /// reference : https://vldb.gsi.go.jp/sokuchi/surveycalc/main.html
+    /// </summary>
+    public static class GeoCoordinateConverter
     {
-      S += A[i] * Math.Sin(2 * i * latitude0);
+        const double EARTH_SEMI_MAJOR_AXIS = 6378137d;  // [m]
+        const double FLATTENING_INV = 298.257222101d;
+        const double SCALE_FACTOR = 0.9999d;
+
+        const double n = 1d / (2d * FLATTENING_INV - 1d);
+        const double n2 = n * n;
+        const double n3 = n2 * n;
+        const double n4 = n3 * n;
+        const double n5 = n4 * n;
+        const double n6 = n5 * n;
+
+        static readonly double[] A = new double[6]
+        {
+            1 + n2 / 4 + n4 / 64,
+            -3d / 2d*(n - n3 / 8 - n5 / 64),
+            15d / 16d * (n2 - n4 / 4),
+            -35d / 48d * (n3 - 5d / 16d * n5),
+            315d / 512d * n4,
+            -693d / 1280d * n5
+        };
+        static readonly double A_b = SCALE_FACTOR * EARTH_SEMI_MAJOR_AXIS / (1 + n) * A[0];
+
+        static readonly double[] beta = new double[6]
+        {
+            0,
+            1d / 2d * n - 2d / 3d * n2 + 37d / 96d * n3 - 1d / 360d * n4 - 81d / 512d * n5,
+            1d / 48d * n2 + 1d / 15d * n3 - 437d / 1440d * n4 + 46d / 105d * n5,
+            17d / 480d * n3 - 37d / 840d * n4 - 209d / 4480d * n5,
+            4397d / 161280d * n4 - 11d / 504d * n5,
+            4583d / 161280d * n5
+        };
+
+        static readonly double[] delta = new double[7]
+        {
+            0,
+            2d * n - 2d / 3d * n2 - 2d * n3 + 116d / 45d * n4 + 26d / 45d * n5 - 2854d / 675d * n6,
+            7d / 3d * n2 - 8d / 5d * n3 - 227d / 45d * n4 + 2704d / 315d * n5 + 2323d / 945d * n6,
+            56d / 15d * n3 - 136d / 35d * n4 - 1262d / 105d * n5 + 73814d / 2835d * n6,
+            4279d / 630d * n4 - 332d / 35d * n5 - 399572d / 14175d * n6,
+            4174d / 315d * n5 - 144838d / 6237d * n6,
+            601676d / 22275d * n6
+        };
+
+        public static GeoCoordinate Cartesian2Geo(Vector3 cartesian, GeoCoordinate origin)
+        {
+            double latitude0 = Deg2Rad(origin.Latitude);
+            double longitude0 = Deg2Rad(origin.Longitude);
+
+            double S = A[0] * latitude0;
+            for(int i = 1; i <= 5; i++)
+            {
+                S += A[i] * Math.Sin(2 * i * latitude0);
+            }
+            S = S * (SCALE_FACTOR * EARTH_SEMI_MAJOR_AXIS) / (1 + n);
+
+            double xi = (cartesian.z + S) / A_b;
+            double eta = cartesian.x / (A_b);
+
+            double xi_d = xi;
+            double eta_d = eta;
+            double sigma_d = 1;
+            double tau_d = 0;
+            for(int i = 1; i <= 5; i++)
+            {
+                int i2 = 2 * i;
+                xi_d -= beta[i] * Math.Sin(i2 * xi) * Math.Cosh(i2 * eta);
+                eta_d -= beta[i] * Math.Cos(i2 * xi) * Math.Sinh(i2 * eta);
+                sigma_d -= beta[i] * Math.Cos(i2 * xi) * Math.Cosh(i2 * eta) * i2;
+                tau_d += beta[i] * Math.Sin(i2 * xi) * Math.Sinh(i2 * eta) * i2;
+            }
+
+            double chi = Math.Asin(Math.Sin(xi_d) / Math.Cosh(eta_d));
+
+            double latitude = chi;
+            for(int i = 1; i <= 6; i++)
+            {
+                latitude += delta[i] * Math.Sin(2 * i * chi);
+            }
+
+            return new GeoCoordinate(
+                Rad2Deg(latitude),
+                Rad2Deg(longitude0 + Math.Atan(Math.Sinh(eta_d) / Math.Cos(xi_d))),
+                cartesian.y - origin.Altitude
+            );
+        }
+
+        private static double Deg2Rad(double deg) => deg * Math.PI / 180d;
+        private static double Rad2Deg(double rad) => rad * 180d / Math.PI;
     }
-    S = S * (SCALE_FACTOR * EARTH_SEMI_MAJOR_AXIS) / (1 + n);
-
-    double xi = (cartesian.z + S) / A_b;
-    double eta = cartesian.x / (A_b);
-
-    double xi_d = xi;
-    double eta_d = eta;
-    double sigma_d = 1;
-    double tau_d = 0;
-    for(int i = 1; i <= 5; i++)
-    {
-      int i2 = 2 * i;
-      xi_d -= beta[i] * Math.Sin(i2 * xi) * Math.Cosh(i2 * eta);
-      eta_d -= beta[i] * Math.Cos(i2 * xi) * Math.Sinh(i2 * eta);
-      sigma_d -= beta[i] * Math.Cos(i2 * xi) * Math.Cosh(i2 * eta) * i2;
-      tau_d += beta[i] * Math.Sin(i2 * xi) * Math.Sinh(i2 * eta) * i2;
-    }
-
-    double chi = Math.Asin(Math.Sin(xi_d) / Math.Cosh(eta_d));
-
-    double latitude = chi;
-    for(int i = 1; i <= 6; i++)
-    {
-      latitude += delta[i] * Math.Sin(2 * i * chi);
-    }
-
-    return new GeoCoordinate(
-      Rad2Deg(latitude),
-      Rad2Deg(longitude0 + Math.Atan(Math.Sinh(eta_d) / Math.Cos(xi_d))),
-      cartesian.y - origin.Altitude
-    );
-  }
-
-  private static double Deg2Rad(double deg) => deg * Math.PI / 180d;
-  private static double Rad2Deg(double rad) => rad * 180d / Math.PI;
-}
 }

--- a/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinateConverter.cs.meta
+++ b/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinateConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40216e7a5bd3c5c09873197e65f055a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scripts/Sensors/Gnss/GnssRos2NavSatFixPublisher.cs
+++ b/Assets/AWSIM/Scripts/Sensors/Gnss/GnssRos2NavSatFixPublisher.cs
@@ -1,0 +1,118 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using ROS2;
+
+namespace AWSIM
+{
+    /// <summary>
+    /// Convert the data output from GnssSensor to ROS2 NavSatFix msg and Publish.
+    /// </summary>
+    [RequireComponent(typeof(GnssSensor))]
+    public class GnssRos2NavSatFixPublisher : MonoBehaviour
+    {
+        private enum Status
+        {
+            STATUS_NO_FIX = -1,
+            STATUS_FIX = 0,
+            STATUS_SBAS_FIX = 1,
+            STATUS_GBAS_FIX = 2,
+        }
+
+        private enum Service
+        {
+            SERVICE_GPS = 1,
+            SERVICE_GLONASS = 2,
+            SERVICE_COMPASS = 4,
+            SERVICE_GALILEO = 8,
+        }
+
+        [System.Serializable]
+        private struct NavSatStatus
+        {
+            public Status status;
+            public Service service;
+        }
+
+        /// <summary>
+        /// Topic name in navSatFix msg.
+        /// </summary>
+        public string navSatFixTopic = "/sensing/gnss/nav_sat_fix";
+
+        /// <summary>
+        /// Gnss sensor frame id.
+        /// </summary>
+        public string frameId = "gnss_link";
+
+        /// <summary>
+        /// NavSatStatus
+        /// </summary>
+        [SerializeField]
+        private NavSatStatus navSatStatus = new NavSatStatus()
+        {
+            status = Status.STATUS_FIX,
+            service = Service.SERVICE_GPS,
+        };
+
+        /// <summary>
+        /// QoS settings.
+        /// </summary>
+        public QoSSettings qosSettings;
+
+        IPublisher<sensor_msgs.msg.NavSatFix> navSatFixPublisher;
+        sensor_msgs.msg.NavSatFix navSatFixMsg;
+        GnssSensor gnssSensor;
+
+        void Start()
+        {
+            // Get GnssSensor component.
+            gnssSensor = GetComponent<GnssSensor>();
+
+            // Set callback.
+            gnssSensor.OnOutputData += Publish;
+
+            // Create msg.
+            navSatFixMsg = new sensor_msgs.msg.NavSatFix()
+            {
+                Header = new std_msgs.msg.Header()
+                {
+                    Frame_id = frameId,
+                },
+                Status = new sensor_msgs.msg.NavSatStatus(),
+                Latitude = 0,
+                Longitude = 0,
+                Altitude = 0
+            };
+            for (int i = 0; i < navSatFixMsg.Position_covariance.Length; i++)
+                navSatFixMsg.Position_covariance[i] = 0;
+
+            // Create publisher.
+            var qos = qosSettings.GetQoSProfile();
+            navSatFixPublisher = SimulatorROS2Node.CreatePublisher<sensor_msgs.msg.NavSatFix>(navSatFixTopic, qos);
+        }
+
+        void Publish(GnssSensor.OutputData outputData)
+        {
+            // Update NavSatStatus.
+            navSatFixMsg.Status.Status = (sbyte)navSatStatus.status;
+            navSatFixMsg.Status.Service = (ushort)navSatStatus.service;
+
+            // Converts data output from GnssSensor to ROS2 msg.
+            navSatFixMsg.Latitude = outputData.GeoCoordinate.Latitude;
+            navSatFixMsg.Longitude = outputData.GeoCoordinate.Longitude;
+            navSatFixMsg.Altitude = outputData.GeoCoordinate.Altitude;
+
+            // Update msg header.
+            var navSatFixHeader = navSatFixMsg as MessageWithHeader;
+            SimulatorROS2Node.UpdateROSTimestamp(ref navSatFixHeader);
+
+            // Publish to ROS2.
+            navSatFixPublisher.Publish(navSatFixMsg);
+        }
+
+        void OnDestroy()
+        {
+            SimulatorROS2Node.RemovePublisher<sensor_msgs.msg.NavSatFix>(navSatFixPublisher);
+        }
+    }
+}

--- a/Assets/AWSIM/Scripts/Sensors/Gnss/GnssRos2NavSatFixPublisher.cs.meta
+++ b/Assets/AWSIM/Scripts/Sensors/Gnss/GnssRos2NavSatFixPublisher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83b35ef92f5a0c3a7a8d5eeb2905729b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scripts/Sensors/Gnss/GnssSensor.cs
+++ b/Assets/AWSIM/Scripts/Sensors/Gnss/GnssSensor.cs
@@ -5,6 +5,8 @@ using UnityEngine.Events;
 
 namespace AWSIM
 {
+    using Geographic;
+
     /// <summary>
     /// GNSS sensor.
     /// Publish pose and poseWithCovarianceStamped in MGRS coordinate system.
@@ -24,10 +26,12 @@ namespace AWSIM
             /// not the Unity world coordinate system position.)
             /// </summary>
             public Vector3 MgrsPosition;
+            public GeoCoordinate GeoCoordinate;
 
             public OutputData()
             {
                 MgrsPosition = new Vector3();
+                GeoCoordinate = new GeoCoordinate();
             }
         }
 
@@ -69,8 +73,10 @@ namespace AWSIM
             timer = 0;
 
             // update mgrs position.
-            var rosPosition = ROS2Utility.UnityToRosPosition(m_transform.position);
+            var unityPosition = m_transform.position;
+            var rosPosition = ROS2Utility.UnityToRosPosition(unityPosition);
             outputData.MgrsPosition = rosPosition + Environment.Instance.MgrsOffsetPosition;   // ros gnss sensor's pos + mgrs offset pos.
+            outputData.GeoCoordinate = GeoCoordinateConverter.Cartesian2Geo(unityPosition, Environment.Instance.WorldOriginGeoCoordinate);
 
             // Calls registered callbacks
             OnOutputData.Invoke(outputData);


### PR DESCRIPTION
- add geographic coordinate calculation scripts (`GeoCoordinate.cs`, `GeoCoordinateConverter.cs`)
- add parameter that can be set from the Inspector window for geographic calculation to `Environment.cs`
- add `GnssRos2NavSatFixPublisher.cs` to publish `sensor_msgs/NavSatFix` topic
To minimize impact on other projects, it's implemented separately from the existing GnssRos2Publisher.

The motivation is to test `eagleye` at runtime with AWSIM.

ref link:
Geographpic coordinate calculations are implemented with reference to the following sites
=> https://vldb.gsi.go.jp/sokuchi/surveycalc/main.html