### PR TITLE
Fix VehicleRos2Input causing SilentError in binary AWSIM

### DIFF
--- a/Assets/AWSIM/Scripts/Vehicles/VehicleRos2Input.cs
+++ b/Assets/AWSIM/Scripts/Vehicles/VehicleRos2Input.cs
@@ -99,7 +99,7 @@ namespace AWSIM
                             return;
                         }
 
-                        validateAndSetVehicleCommand(msg);
+                        ValidateAndSetVehicleCommand(msg);
                     }, qos);
 
             gearCommandSubscriber
@@ -121,7 +121,7 @@ namespace AWSIM
                     });
         }
 
-        void validateAndSetVehicleCommand(autoware_auto_control_msgs.msg.AckermannControlCommand command)
+        void ValidateAndSetVehicleCommand(autoware_auto_control_msgs.msg.AckermannControlCommand command)
         {
             if (Single.IsNaN(command.Longitudinal.Acceleration))
             {

--- a/Assets/AWSIM/Scripts/Vehicles/VehicleRos2Input.cs
+++ b/Assets/AWSIM/Scripts/Vehicles/VehicleRos2Input.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -93,10 +94,12 @@ namespace AWSIM
                     {
                         // highest priority is EMERGENCY.
                         // If Emergency is true, ControlCommand is not used for vehicle acceleration input.
-                        if (!isEmergency)
-                            AccelerationInput = msg.Longitudinal.Acceleration;
+                        if (isEmergency)
+                        {
+                            return;
+                        }
 
-                        SteeringInput = -(float)msg.Lateral.Steering_tire_angle * Mathf.Rad2Deg;
+                        validateAndSetVehicleCommand(msg);
                     }, qos);
 
             gearCommandSubscriber
@@ -116,6 +119,29 @@ namespace AWSIM
                         if (isEmergency)
                             AccelerationInput = emergencyDeceleration;
                     });
+        }
+
+        void validateAndSetVehicleCommand(autoware_auto_control_msgs.msg.AckermannControlCommand command)
+        {
+            if (Single.IsNaN(command.Longitudinal.Acceleration))
+            {
+                Debug.LogError($"AccelerationInput NaN. Setting EmergencyDeceleration");
+                AccelerationInput = emergencyDeceleration;
+            }
+            else
+            {
+                AccelerationInput = command.Longitudinal.Acceleration;
+            }
+
+            if (Single.IsNaN(command.Lateral.Steering_tire_angle))
+            {
+                Debug.LogError($"SteeringInput NaN. Setting 0");
+                SteeringInput = 0.0f;
+            }
+            else
+            {
+                SteeringInput = -(float)command.Lateral.Steering_tire_angle * Mathf.Rad2Deg;
+            }
         }
 
         void OnDisable()


### PR DESCRIPTION
# Description

The PR solves the issue of disappearing scenes in AWSIM. The problem happens in binary AWSIM, it was not observed when working in Unity Editor.

## Details

When publishing floating values from Autoware to AWSIM, sometimes NaN values are filled in messages, instead of proper numeric values. This causes the built binary to silently unload the scene, without any logging in Unity `Player.log` file.

## How to reproduce

To reproduce the issue:
- build the AWSIM binary from Unity Editor
- source the ROS2 workspace containing [autoware_auto_msgs](https://github.com/tier4/autoware_auto_msgs)
- in one terminal publish the GearCommand

```
ros2 topic pub /control/command/gear_cmd  autoware_auto_vehicle_msgs/msg/GearCommand "stamp:
  sec: 0
  nanosec: 0
command: 2" 
```

- in second terminal publish the ControlCommand

```
ros2 topic pub /control/command/control_cmd autoware_auto_control_msgs/msg/AckermannControlCommand "stamp:
  sec: 1722520890
  nanosec: 0
lateral:
  stamp:
    sec: 0
    nanosec: 0
  steering_tire_angle: nan
  steering_tire_rotation_rate: nan
longitudinal:
  stamp:
    sec: 0
    nanosec: 0
  speed: NaN
  acceleration: nan
  jerk: nan" -r 10
```

The video below shows how the binary behaves before the fix

[Before.webm](https://github.com/user-attachments/assets/c9c99039-029b-4149-a99d-05e55c3cee61)

The video below shows how the binary behaves after the fix

[After.webm](https://github.com/user-attachments/assets/3f414b76-5433-4696-9811-c834e3858646)

