### PR TITLE
fix GeoCoordinate parameter accessibility from inspector

### DIFF
--- a/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinate.cs
+++ b/Assets/AWSIM/Scripts/GeoCoordinate/GeoCoordinate.cs
@@ -1,24 +1,33 @@
+using UnityEngine;
+
 namespace AWSIM.Geographic
 {
     [System.Serializable]
     public class GeoCoordinate
     {
-        public double Latitude { get; }
-        public double Longitude { get; }
-        public double Altitude { get; }
+        [SerializeField]
+        private double latitude;
+        [SerializeField]
+        private double longitude;
+        [SerializeField]
+        private double altitude;
+
+        public double Latitude => latitude;
+        public double Longitude => longitude;
+        public double Altitude => altitude;
 
         public GeoCoordinate()
         {
-            Latitude = 0;
-            Longitude = 0;
-            Altitude = 0;
+            latitude = 0;
+            longitude = 0;
+            altitude = 0;
         }
 
         public GeoCoordinate(double latitude, double longitude, double altitude)
         {
-            Latitude = latitude;
-            Longitude = longitude;
-            Altitude = altitude;
+            this.latitude = latitude;
+            this.longitude = longitude;
+            this.altitude = altitude;
         }
     }
 }


### PR DESCRIPTION
Regarding the feature added in #340, 
my incorrect fix prevented `worldOriginGeoCoordinate` parameter in Environment.cs from being set from the inspector.

This PR fixes that issue.

Before:
![image](https://github.com/user-attachments/assets/d174fdef-8018-407b-b559-085b13bcfcb3)

After:
![image](https://github.com/user-attachments/assets/ef6c1fdb-85a5-4429-a51f-1515267155ef)
