### PR TITLE
feat: make gnss calculation relative to Environment transform

### DIFF
--- a/Assets/AWSIM/Scripts/Sensors/Gnss/GnssSensor.cs
+++ b/Assets/AWSIM/Scripts/Sensors/Gnss/GnssSensor.cs
@@ -56,10 +56,12 @@ namespace AWSIM
         float timer = 0;
         OutputData outputData = new OutputData();
         Transform m_transform;
+        Transform envTransform;
 
         void Start()
         {
             m_transform = transform;
+            envTransform = Environment.Instance.transform;
         }
 
         void FixedUpdate()
@@ -73,7 +75,7 @@ namespace AWSIM
             timer = 0;
 
             // update mgrs position.
-            var unityPosition = m_transform.position;
+            var unityPosition = envTransform.InverseTransformPoint(m_transform.position);
             var rosPosition = ROS2Utility.UnityToRosPosition(unityPosition);
             outputData.MgrsPosition = rosPosition + Environment.Instance.MgrsOffsetPosition;   // ros gnss sensor's pos + mgrs offset pos.
             outputData.GeoCoordinate = GeoCoordinateConverter.Cartesian2Geo(unityPosition, Environment.Instance.WorldOriginGeoCoordinate);


### PR DESCRIPTION
This change in PR makes the coordinates used by GNSS in its calculations relative to the Transform of the `Environment`.

This is to deal with the case when the environmental model used in AWSIM is sometimes not what the GNSS expects (Z-axis is longitude, X-axis is latitude).

This change does not affect projects where the posture of the GameObject to which the `Environment` component is attached has not been changed.