### PR TITLE
feat: first order lag for vehicle control

### DIFF
--- a/Assets/AWSIM/Scripts/Vehicles/FirstOrderLaggedFloat.cs
+++ b/Assets/AWSIM/Scripts/Vehicles/FirstOrderLaggedFloat.cs
@@ -1,0 +1,59 @@
+using System;
+using UnityEngine;
+
+namespace AWSIM
+{
+    public class FirstOrderLaggedFloat
+    {
+        private float timeConstant;
+
+        private float desiredValue;
+        private float currentValue;
+        private float lastTime;
+
+        public float Value
+        {
+            get
+            {
+                Update();
+                return currentValue;
+            }
+        }
+        public float DesiredValue
+        {
+            set
+            {
+                Update();
+                desiredValue = value;
+            }
+            get
+            {
+                return desiredValue;
+            }
+        }
+
+        public FirstOrderLaggedFloat(float timeConstant, float initialValue)
+        {
+            this.timeConstant = timeConstant;
+
+            desiredValue = currentValue = initialValue;
+            lastTime = Time.time;
+        }
+
+        private void Update()
+        {
+            float dt = Time.time - lastTime;
+
+            if (timeConstant == 0.0f)
+            {
+                currentValue = desiredValue;
+            }
+            else
+            {
+                currentValue += (dt / timeConstant) * (desiredValue - currentValue);
+            }
+
+            lastTime = Time.time;
+        }
+    }
+}

--- a/Assets/AWSIM/Scripts/Vehicles/FirstOrderLaggedFloat.cs.meta
+++ b/Assets/AWSIM/Scripts/Vehicles/FirstOrderLaggedFloat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 963ca01e17396605cbc15c9a3f20e472
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Scripts/Vehicles/Vehicle.cs
+++ b/Assets/AWSIM/Scripts/Vehicles/Vehicle.cs
@@ -196,8 +196,14 @@ namespace AWSIM
         /// Vehicle steering input. Tire angle (degree)
         /// Negative is left, positive is right turn tire angle.
         /// </summary>
-        // TODO: Compute first order lag
-        public float SteerAngleInput;
+        public float SteerAngleInput
+        {
+            get => steerAngle.DesiredValue;
+            set => steerAngle.DesiredValue = Mathf.Clamp(value, -MaxSteerAngleInput, MaxSteerAngleInput);
+        }
+        private FirstOrderLaggedFloat steerAngle;
+        [SerializeField, Min(0.0f), Tooltip("Set 0 to disable the lag")]
+        private float steerAngleTimeConstant = 0.0f;
 
         /// <summary>
         /// Vehicle turn signal input. NONE, LEFT, RIGHT, HAZARD.
@@ -217,7 +223,7 @@ namespace AWSIM
         /// <summary>
         /// Vehicle steering angle (degree)
         /// </summary>
-        public float SteerAngle => SteerAngleInput;
+        public float SteerAngle => steerAngle.Value;
 
         public float SteerAngleNormalized => SteerAngle / MaxSteerAngleInput;
 
@@ -296,6 +302,9 @@ namespace AWSIM
             // Initialize with non-slip value
             ForwardSlipMultipler = 1f;
             SidewaySlipMultipler = 1f;
+
+            // Initialize steer angle
+            steerAngle = new FirstOrderLaggedFloat(steerAngleTimeConstant, 0.0f);
         }
 
         // GroundSlipMultiplier changes the slip rate.
@@ -324,7 +333,6 @@ namespace AWSIM
         {
             // Clamp input values.
             AccelerationInput = Mathf.Clamp(AccelerationInput, -MaxAccelerationInput, MaxAccelerationInput);
-            SteerAngleInput = Mathf.Clamp(SteerAngleInput, -MaxSteerAngleInput, MaxSteerAngleInput);
 
             // Compute vehicle infomation.
             ComputeVehicleState();

--- a/Assets/AWSIM/Scripts/Vehicles/Vehicle.cs
+++ b/Assets/AWSIM/Scripts/Vehicles/Vehicle.cs
@@ -171,11 +171,15 @@ namespace AWSIM
         // -MaxSteerAngleInput <= SteerAngleInput <= MaxSteerAngleInput.
         [Range(0.01f, 80)]
         public float MaxSteerAngleInput = 25f;
+        [SerializeField, Min(0.0f), Tooltip("Set 0 to disable the lag")]
+        private float steerAngleTimeConstant = 0.0f;
 
         // Set value to clamp AccelerationInput (m/s^2).
         // -MaxAccelerationInput <= AccelerationInput <= MaxAccelerationInput.
         [Range(0.01f, 50)]
         public float MaxAccelerationInput = 10;
+        [SerializeField, Min(0.0f), Tooltip("Set 0 to disable the lag")]
+        private float accelerationTimeConstant = 0.0f;
 
         [Header("Inputs")]
 
@@ -195,8 +199,6 @@ namespace AWSIM
             set => acceleration.DesiredValue = Mathf.Clamp(value, -MaxAccelerationInput, MaxAccelerationInput);
         }
         private FirstOrderLaggedFloat acceleration;
-        [SerializeField, Min(0.0f), Tooltip("Set 0 to disable the lag")]
-        private float accelerationTimeConstant = 0.0f;
 
         /// <summary>
         /// Vehicle steering input. Tire angle (degree)
@@ -208,8 +210,6 @@ namespace AWSIM
             set => steerAngle.DesiredValue = Mathf.Clamp(value, -MaxSteerAngleInput, MaxSteerAngleInput);
         }
         private FirstOrderLaggedFloat steerAngle;
-        [SerializeField, Min(0.0f), Tooltip("Set 0 to disable the lag")]
-        private float steerAngleTimeConstant = 0.0f;
 
         /// <summary>
         /// Vehicle turn signal input. NONE, LEFT, RIGHT, HAZARD.


### PR DESCRIPTION
Add first order delay for AWSIM vehicle control(acceleration and steering).
Since the public property names are unchanged, it is fully compatible with the existing `Vehicle.cs`.

This adds the configurable variable ([s]) to the Vehicle.cs inspector.
When the time constant is set to 0, the delay is disabled and an ideal response is obtained.

As a reminder, these variables are only set during the initialization of the `FirstOrderLaggedFloat` object, so parameter changes during the simulation run are not supported.

![image](https://github.com/user-attachments/assets/8bb14695-2cd6-4739-852d-5c839a883e6b)

