### PR TITLE
Fix: calculate distance to next lane and intersection using NPC route instead of 3D distance

### DIFF
--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
@@ -142,7 +142,7 @@ namespace AWSIM.TrafficSimulation
                 out var laneLenght);
             return (1f - laneFollowingProgress) * laneLenght;
         }
-        
+
         public float DistanceToClosestTrafficLane()
         {
             if (TrafficLightLane is null && !FollowingLanes.Contains(TrafficLightLane))

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
@@ -106,9 +106,7 @@ namespace AWSIM.TrafficSimulation
             => SignedDistanceToPointOnLane(CurrentWaypoint);
 
         public float DistanceToNextLane
-            => CurrentFollowingLane?.Waypoints?.Any() != true ? float.MaxValue
-            : SignedDistanceToPointOnLane(CurrentFollowingLane.Waypoints.Last());
-
+            => CalculateDistanceToNextLane();
         public float DistanceToIntersection
             => FirstLaneWithIntersection == null ? float.MaxValue
             : DistanceToClosestTrafficLane();
@@ -128,6 +126,22 @@ namespace AWSIM.TrafficSimulation
 
             var distance = Vector3.Distance(position, point);
             return hasPassedThePoint ? -distance : distance;
+        }
+
+        private float CalculateDistanceToNextLane()
+        {
+            var nextLane = CurrentFollowingLane;
+            if (nextLane == null || nextLane.Waypoints == null || nextLane.Waypoints.Length == 0)
+            {
+                return float.MaxValue;
+            }
+            var vehiclePosition = FrontCenterPosition;
+            RandomTrafficUtils.GetLaneFollowingProgressAndLaneLength(
+                vehiclePosition,
+                nextLane,
+                out var laneFollowingProgress,
+                out var laneLenght);
+            return (1f - laneFollowingProgress) * laneLenght;
         }
         
         public float DistanceToClosestTrafficLane()

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
@@ -109,7 +109,7 @@ namespace AWSIM.TrafficSimulation
             => CalculateDistanceToNextLane();
         public float DistanceToIntersection
             => FirstLaneWithIntersection == null ? float.MaxValue
-            : DistanceToClosestTrafficLane();
+            : DistanceToClosestTrafficLightLane();
 
         public bool ObstructedByVehicleBehindIntersection => DistanceToIntersection > DistanceToFrontVehicle;
 
@@ -143,7 +143,7 @@ namespace AWSIM.TrafficSimulation
             return (1f - laneFollowingProgress) * laneLenght;
         }
 
-        public float DistanceToClosestTrafficLane()
+        public float DistanceToClosestTrafficLightLane()
         {
             if (TrafficLightLane is null && !FollowingLanes.Contains(TrafficLightLane))
             {
@@ -179,12 +179,9 @@ namespace AWSIM.TrafficSimulation
                 }
                 else
                 {
-                    //when distance was calculated once partially/for whole lane it keeps calculating whole lanes
-                    //until meeting traffic light lane
                     distance += laneLenght;
                 }
 
-                //if traffic lane, stop computing
                 if (FollowingLanes[i] == TrafficLightLane)
                 {
                     break;

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs
@@ -115,7 +115,6 @@ namespace AWSIM.TrafficSimulation
 
         private int routeIndex = 0;
 
-        // TODO: Calculate distance along the lane
         public float SignedDistanceToPointOnLane(Vector3 point)
         {
             var position = FrontCenterPosition;

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
@@ -121,8 +121,11 @@ namespace AWSIM.TrafficSimulation
 
             for (var i = 0; i < state.FollowingLanes.Count; i++)
             {
-                (var laneFollowingProgress, var laneLenght) =
-                    GetLaneFollowingProgressAndLaneLength(vehiclePosition, state.FollowingLanes[i]);
+                RandomTrafficUtils.GetLaneFollowingProgressAndLaneLength(
+                    vehiclePosition,
+                    state.FollowingLanes[i],
+                    out var laneFollowingProgress,
+                    out var laneLenght);
                 if (!startAddingWholeLanesDistance)
                 {
                     //vehicle is before first not-skipped lane
@@ -153,48 +156,6 @@ namespace AWSIM.TrafficSimulation
                 }
             }
             return distance;
-        }
-
-        public static (float, float) GetLaneFollowingProgressAndLaneLength(Vector3 position, TrafficLane lane)
-        {
-            if (lane is null)
-            {
-                return (-1f, -1f);
-            }
-
-            float lengthToPointOnLane = 0.0f;
-            float wholeLaneLength = 0.0f;
-            float eps = 0.01f;
-            Vector2 positionXZ = new Vector2(position.x, position.z);
-            for (var i = 0; i < lane.Waypoints.Length - 1; i++)
-            {
-                Vector2 segmentStart = new Vector2(lane.Waypoints[i].x, lane.Waypoints[i].z);
-                Vector2 segmentEnd = new Vector2(lane.Waypoints[i + 1].x, lane.Waypoints[i + 1].z);
-                Vector2 pointOnSegment = ClosestPointOnSegment(segmentStart, segmentEnd, positionXZ);
-                float distanceFromStart = Vector2.Distance(segmentStart, pointOnSegment);
-                if (distanceFromStart > eps)
-                {
-                    lengthToPointOnLane += distanceFromStart;
-                }
-
-                wholeLaneLength += Vector2.Distance(segmentStart, segmentEnd);
-            }
-
-            return ((lengthToPointOnLane / wholeLaneLength), wholeLaneLength);
-        }
-
-        public static Vector2 ClosestPointOnSegment(Vector2 segmentStart, Vector2 segmentStop, Vector2 pointOfInterest)
-        {
-            Vector2 segmentVector = segmentStop - segmentStart;
-            Vector2 segmentStartToPoiVector = pointOfInterest - segmentStart;
-
-            float segmentMagnitude = segmentVector.sqrMagnitude;
-            float dotProduct = Vector2.Dot(segmentStartToPoiVector, segmentVector);
-            float argument = dotProduct / segmentMagnitude;
-
-            float t = Mathf.Clamp01(argument);
-
-            return segmentStart + t * segmentVector;
         }
 
         private static float CalculateYieldingDistance(NPCVehicleInternalState state)

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
@@ -91,7 +91,7 @@ namespace AWSIM.TrafficSimulation
             var distanceToStopPointByTrafficLight = float.MaxValue;
             if (state.TrafficLightLane != null)
             {
-                var distanceToStopLine = DistanceToClosestTrafficLane(state);
+                var distanceToStopLine = state.DistanceToClosestTrafficLane();
                 switch (state.TrafficLightPassability)
                 {
                     case TrafficLightPassability.GREEN:
@@ -106,56 +106,6 @@ namespace AWSIM.TrafficSimulation
                 }
             }
             return onlyGreaterThan(distanceToStopPointByTrafficLight, 0);
-        }
-
-        private static float DistanceToClosestTrafficLane(NPCVehicleInternalState state)
-        {
-            if (state.TrafficLightLane is null && !state.FollowingLanes.Contains(state.TrafficLightLane))
-            {
-                return float.MaxValue;
-            }
-
-            var distance = 0f;
-            var vehiclePosition = state.FrontCenterPosition;
-            bool startAddingWholeLanesDistance = false;
-
-            for (var i = 0; i < state.FollowingLanes.Count; i++)
-            {
-                RandomTrafficUtils.GetLaneFollowingProgressAndLaneLength(
-                    vehiclePosition,
-                    state.FollowingLanes[i],
-                    out var laneFollowingProgress,
-                    out var laneLenght);
-                if (!startAddingWholeLanesDistance)
-                {
-                    //vehicle is before first not-skipped lane
-                    if (laneFollowingProgress <= 0f)
-                    {
-                        distance += laneLenght;
-                        startAddingWholeLanesDistance = true;
-                    }
-                    //vehicle is on lane
-                    else if (laneFollowingProgress < 1f)
-                    {
-                        var progressToLaneEnd = (1 - laneFollowingProgress);
-                        distance += laneLenght * progressToLaneEnd;
-                        startAddingWholeLanesDistance = true;
-                    }
-                }
-                else
-                {
-                    //when distance was calculated once partially/for whole lane it keeps calculating whole lanes
-                    //until meeting traffic light lane
-                    distance += laneLenght;
-                }
-
-                //if traffic lane, stop computing
-                if (state.FollowingLanes[i] == state.TrafficLightLane)
-                {
-                    break;
-                }
-            }
-            return distance;
         }
 
         private static float CalculateYieldingDistance(NPCVehicleInternalState state)

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
@@ -91,7 +91,7 @@ namespace AWSIM.TrafficSimulation
             var distanceToStopPointByTrafficLight = float.MaxValue;
             if (state.TrafficLightLane != null)
             {
-                var distanceToStopLine = state.DistanceToClosestTrafficLane();
+                var distanceToStopLine = state.DistanceToClosestTrafficLightLane();
                 switch (state.TrafficLightPassability)
                 {
                     case TrafficLightPassability.GREEN:

--- a/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs
@@ -91,8 +91,7 @@ namespace AWSIM.TrafficSimulation
             var distanceToStopPointByTrafficLight = float.MaxValue;
             if (state.TrafficLightLane != null)
             {
-                var distanceToStopLine =
-                    state.SignedDistanceToPointOnLane(state.TrafficLightLane.StopLine.CenterPoint);
+                var distanceToStopLine = DistanceToClosestTrafficLane(state);
                 switch (state.TrafficLightPassability)
                 {
                     case TrafficLightPassability.GREEN:
@@ -107,6 +106,95 @@ namespace AWSIM.TrafficSimulation
                 }
             }
             return onlyGreaterThan(distanceToStopPointByTrafficLight, 0);
+        }
+
+        private static float DistanceToClosestTrafficLane(NPCVehicleInternalState state)
+        {
+            if (state.TrafficLightLane is null && !state.FollowingLanes.Contains(state.TrafficLightLane))
+            {
+                return float.MaxValue;
+            }
+
+            var distance = 0f;
+            var vehiclePosition = state.FrontCenterPosition;
+            bool startAddingWholeLanesDistance = false;
+
+            for (var i = 0; i < state.FollowingLanes.Count; i++)
+            {
+                (var laneFollowingProgress, var laneLenght) =
+                    GetLaneFollowingProgressAndLaneLength(vehiclePosition, state.FollowingLanes[i]);
+                if (!startAddingWholeLanesDistance)
+                {
+                    //vehicle is before first not-skipped lane
+                    if (laneFollowingProgress <= 0f)
+                    {
+                        distance += laneLenght;
+                        startAddingWholeLanesDistance = true;
+                    }
+                    //vehicle is on lane
+                    else if (laneFollowingProgress < 1f)
+                    {
+                        var progressToLaneEnd = (1 - laneFollowingProgress);
+                        distance += laneLenght * progressToLaneEnd;
+                        startAddingWholeLanesDistance = true;
+                    }
+                }
+                else
+                {
+                    //when distance was calculated once partially/for whole lane it keeps calculating whole lanes
+                    //until meeting traffic light lane
+                    distance += laneLenght;
+                }
+
+                //if traffic lane, stop computing
+                if (state.FollowingLanes[i] == state.TrafficLightLane)
+                {
+                    break;
+                }
+            }
+            return distance;
+        }
+
+        public static (float, float) GetLaneFollowingProgressAndLaneLength(Vector3 position, TrafficLane lane)
+        {
+            if (lane is null)
+            {
+                return (-1f, -1f);
+            }
+
+            float lengthToPointOnLane = 0.0f;
+            float wholeLaneLength = 0.0f;
+            float eps = 0.01f;
+            Vector2 positionXZ = new Vector2(position.x, position.z);
+            for (var i = 0; i < lane.Waypoints.Length - 1; i++)
+            {
+                Vector2 segmentStart = new Vector2(lane.Waypoints[i].x, lane.Waypoints[i].z);
+                Vector2 segmentEnd = new Vector2(lane.Waypoints[i + 1].x, lane.Waypoints[i + 1].z);
+                Vector2 pointOnSegment = ClosestPointOnSegment(segmentStart, segmentEnd, positionXZ);
+                float distanceFromStart = Vector2.Distance(segmentStart, pointOnSegment);
+                if (distanceFromStart > eps)
+                {
+                    lengthToPointOnLane += distanceFromStart;
+                }
+
+                wholeLaneLength += Vector2.Distance(segmentStart, segmentEnd);
+            }
+
+            return ((lengthToPointOnLane / wholeLaneLength), wholeLaneLength);
+        }
+
+        public static Vector2 ClosestPointOnSegment(Vector2 segmentStart, Vector2 segmentStop, Vector2 pointOfInterest)
+        {
+            Vector2 segmentVector = segmentStop - segmentStart;
+            Vector2 segmentStartToPoiVector = pointOfInterest - segmentStart;
+
+            float segmentMagnitude = segmentVector.sqrMagnitude;
+            float dotProduct = Vector2.Dot(segmentStartToPoiVector, segmentVector);
+            float argument = dotProduct / segmentMagnitude;
+
+            float t = Mathf.Clamp01(argument);
+
+            return segmentStart + t * segmentVector;
         }
 
         private static float CalculateYieldingDistance(NPCVehicleInternalState state)

--- a/Assets/AWSIM/Scripts/RandomTraffic/Utils/RandomTrafficUtils.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/Utils/RandomTrafficUtils.cs
@@ -79,7 +79,7 @@ namespace AWSIM.TrafficSimulation
                 ? source[Random.Range(0, source.Count)]
                 : default;
         }
-        
+
         /// <summary>
         /// Calculates where on the lane the position currently is.
         /// Helps to track progress of lane following functionality.

--- a/Assets/AWSIM/Scripts/RandomTraffic/Utils/RandomTrafficUtils.cs
+++ b/Assets/AWSIM/Scripts/RandomTraffic/Utils/RandomTrafficUtils.cs
@@ -79,5 +79,64 @@ namespace AWSIM.TrafficSimulation
                 ? source[Random.Range(0, source.Count)]
                 : default;
         }
+        
+        /// <summary>
+        /// Calculates where on the lane the position currently is.
+        /// Helps to track progress of lane following functionality.
+        /// </summary>
+        /// <param name="position">position for which the progress is calculated</param>
+        /// <param name="lane">lane on which the progress is calculated</param>
+        /// <param name="progress">Out parameter. Represents distance from LaneStart to position projection on segment, relative to whole lane length [0-1 range]</param>
+        /// <param name="laneLength">Out parameter. Represents</param>
+        /// <returns></returns>
+        public static void GetLaneFollowingProgressAndLaneLength(Vector3 position, TrafficLane lane, out float progress, out float laneLength)
+        {
+            if (lane is null)
+            {
+                progress = -1f;
+                laneLength = -1f;
+                return;
+            }
+
+            float lengthToPointOnLane = 0.0f;
+            laneLength = 0.0f;
+            float eps = 0.01f;
+            for (var i = 0; i < lane.Waypoints.Length - 1; i++)
+            {
+                Vector3 segmentStart = lane.Waypoints[i];
+                Vector3 segmentEnd = lane.Waypoints[i+1];
+                Vector3 pointOnSegment = ClosestPointOnSegment(segmentStart, segmentEnd, position);
+                float distanceFromStart = Vector3.Distance(segmentStart, pointOnSegment);
+                if (distanceFromStart > eps)
+                {
+                    lengthToPointOnLane += distanceFromStart;
+                }
+
+                laneLength += Vector3.Distance(segmentStart, segmentEnd);
+            }
+            progress = lengthToPointOnLane / laneLength;
+        }
+
+        /// <summary>
+        /// Calculates closest point on segment to point of interest.
+        /// If point of interest cannot be projected to segment, returns closest end of segment.
+        /// </summary>
+        /// <param name="segmentStart">segment start position</param>
+        /// <param name="segmentStop">segment end position</param>
+        /// <param name="pointOfInterest">point of interest</param>
+        /// <returns>closest point on segment to point of interest</returns>
+        public static Vector3 ClosestPointOnSegment(Vector3 segmentStart, Vector3 segmentStop, Vector3 pointOfInterest)
+        {
+            Vector3 segmentVector = segmentStop - segmentStart;
+            Vector3 segmentStartToPoiVector = pointOfInterest - segmentStart;
+
+            float segmentMagnitude = segmentVector.sqrMagnitude;
+            float dotProduct = Vector3.Dot(segmentStartToPoiVector, segmentVector);
+            float argument = dotProduct / segmentMagnitude;
+
+            float t = Mathf.Clamp01(argument);
+
+            return segmentStart + t * segmentVector;
+        }
     }
 }


### PR DESCRIPTION
# Description

The Random Traffic calculated the distance to the closest traffic light lane in 3D space. The distance did not take the NPC route into account. This can cause situations where NPC stops moving along a lane, since currently it passes a TrafficLight, that it will reach in the future on its route. ([Internal evidence 1](https://tier4.atlassian.net/browse/RJD-1440?focusedCommentId=197496), [Internal evidence 2](https://tier4.atlassian.net/browse/RJD-1452?focusedCommentId=198255))

The PR solves [Internal issue 1](https://tier4.atlassian.net/browse/RJD-1440?focusedCommentId=197496) and [Internal issue 2](https://tier4.atlassian.net/browse/RJD-1452?focusedCommentId=198255)

## Details

The PR introduces:
- calculating a distance to next lane using `FollowingLanes` in `NPCVehicleInternalState`
- calculating a distance to Intersection using `TrafficLightLane` and `FollowingLanes` in `NPCVehicleInternalState`

Part of the implementation is extracted to `RandomTrafficUtils` for better code reusage in the future.

The currently implemented `SignedDistanceToPointOnLane` was left intact for the following situations:
- [DistanceToTargetPoint](https://github.com/tier4/AWSIM/blob/308a9b262f63c788a56546a2cc1da9a210d50cde/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs#L100) and [DistanceToCurrentWaypoint](https://github.com/tier4/AWSIM/blob/308a9b262f63c788a56546a2cc1da9a210d50cde/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/NPCVehicleInternalState.cs#L105) calculate the distance from Vehicle front to `TargetPoint` and `CurrentWaypoint` (green arrow on the image below). As I checked both attributes reference the closest waypoint on a TrafficLane. Calculating the distance in this manner is robust, performing and calculates the distance between the actual position of an NPC and the next waypoint, making it a good solution as is.
![image](https://github.com/user-attachments/assets/88f6c4db-e864-4de6-a121-c5e599cd353a)
- checking if NPC yields in cognition step ([link](https://github.com/tier4/AWSIM/blob/308a9b262f63c788a56546a2cc1da9a210d50cde/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleCognitionStep.cs#L623)) covers checking if NPC went past a yield point (negative distance), which cannot be calculated using `FollowingLanes` since when NPC enters new lane, the lane gets deleted from the list. In this scenario we do not have access to the previous lanes. Even if we had this would increase computation time to analyze previous lanes and would add significant overhead to the calculation process
- yield distance calculation ([link](https://github.com/tier4/AWSIM/blob/308a9b262f63c788a56546a2cc1da9a210d50cde/Assets/AWSIM/Scripts/RandomTraffic/NPCVehicle/Steps/NPCVehicleDecisionStep.cs#L112)) is calculated a couple of times during simulation with 20 NPCs at a scene. It happens mostly when an NPC is approaching to stop at red light before intersection. This is a similar situation to the one from 1st point of this list (`DistanceToTargetPoint` and `DistanceToCurrentWaypoint`) - calculating distance projected on TrafficLane could require much computation time for a small benefit of calculation accuracy
![image](https://github.com/user-attachments/assets/b7433282-3749-4afc-9375-c55a41c8a965)
