### PR TITLE
Change LiDAR default return mode to SingleReturnLast

### DIFF
--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiAT128E2X.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiAT128E2X.prefab
@@ -240,7 +240,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &9115279251508973176
 MonoBehaviour:
@@ -280,7 +280,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 8
-  returnMode: 16777220
+  returnMode: 16777218
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar128E4X.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar128E4X.prefab
@@ -143,7 +143,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &2398431948632788025
 MonoBehaviour:
@@ -183,7 +183,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 11
-  returnMode: 16777220
+  returnMode: 16777218
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar40P.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar40P.prefab
@@ -469,7 +469,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &7675420128049466981
 MonoBehaviour:
@@ -509,7 +509,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 6
-  returnMode: 16777220
+  returnMode: 16777218
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarQT64.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarQT64.prefab
@@ -372,7 +372,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &1430391258634731476
 MonoBehaviour:
@@ -412,7 +412,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 5
-  returnMode: 16777220
+  returnMode: 16777218
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarXT32.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarXT32.prefab
@@ -280,7 +280,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 9
-  returnMode: 16777220
+  returnMode: 16777218
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiQT128C2X.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiQT128C2X.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &1429064023790827067
 MonoBehaviour:
@@ -101,7 +101,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 10
-  returnMode: 16777220
+  returnMode: 16777218
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/OusterOS1-64.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/OusterOS1-64.prefab
@@ -100,7 +100,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 20
   modelPreset: 7
-  returnMode: 16777220
+  returnMode: 16777218
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &4572956135196922574
 MonoBehaviour:
@@ -101,7 +101,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 2
-  returnMode: 16777220
+  returnMode: 16777218
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP32C.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP32C.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &6422033487030486066
 MonoBehaviour:
@@ -101,7 +101,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 3
-  returnMode: 16777220
+  returnMode: 16777218
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLS128.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLS128.prefab
@@ -509,7 +509,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
   modelPreset: 4
-  returnMode: 16777220
+  returnMode: 16777218
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
   applyVelocityDistortion: 0

--- a/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
@@ -234,7 +234,7 @@ namespace RGLUnityPlugin
             if (!simulateBeamDivergence && IsDualReturnMode(returnMode))
             {
                 Debug.LogWarning(
-                    $"Dual return mode without {nameof(simulateBeamDivergence)} enabled will not take effect." +
+                    $"{name}: Dual return mode without {nameof(simulateBeamDivergence)} enabled may not take desired effect." +
                      "Please refer to documentation if the return mode is desired.");
             }
             

--- a/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -228,6 +229,13 @@ namespace RGLUnityPlugin
             else
             {
                 rglGraphLidar.ConfigureNodeRaytraceBeamDivergence(lidarRaytraceNodeId, 0.0f, 0.0f);
+            }
+
+            if (!simulateBeamDivergence && IsDualReturnMode(returnMode))
+            {
+                Debug.LogWarning(
+                    $"Dual return mode without {nameof(simulateBeamDivergence)} enabled will not take effect." +
+                     "Please refer to documentation if the return mode is desired.");
             }
             
             rglGraphLidar.ConfigureNodeRaytraceReturnMode(lidarRaytraceNodeId, returnMode);
@@ -471,6 +479,11 @@ namespace RGLUnityPlugin
             Vector3 localAngularVelocity = (deltaRotation * Mathf.Deg2Rad) / Time.deltaTime;
 
             rglGraphLidar.ConfigureNodeRaytraceVelocity(lidarRaytraceNodeId, localLinearVelocity, localAngularVelocity);
+        }
+
+        private bool IsDualReturnMode(RGLReturnMode mode)
+        {
+            return ((Convert.ToInt32(mode) & (int)RGLReturnCount.DualReturn) == (int)RGLReturnCount.DualReturn);
         }
     }
 }

--- a/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarSensor.cs
@@ -47,7 +47,7 @@ namespace RGLUnityPlugin
         public LidarModel modelPreset = LidarModel.RangeMeter;
 
         [Tooltip("Allows to select between LiDAR return modes")]
-        public RGLReturnMode returnMode = RGLReturnMode.SingleReturnFirst;
+        public RGLReturnMode returnMode = RGLReturnMode.SingleReturnLast;
 
         [Tooltip("Allows to quickly enable/disable distance gaussian noise")]
         public bool applyDistanceGaussianNoise = true;


### PR DESCRIPTION
The PR introduces a default return mode change in RGL LiDAR prefabs. It also introduces Warning when any `DualReturn` mode is chosen, without beam divergence simulation enabled.

More information can be found in the [internal issue](https://tier4.atlassian.net/browse/RJD-1439?focusedCommentId=200153)