### PR TITLE
Improve LiDAR range modifications

### DIFF
--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiAT128E2X.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiAT128E2X.prefab
@@ -240,7 +240,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &9115279251508973176
 MonoBehaviour:
@@ -302,7 +302,7 @@ MonoBehaviour:
     00000000:
       type: {class: HesaiAT128LidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
-        _laserArray:
+        laserArray:
           centerOfMeasurementLinearOffsetMm: {x: -17.1, y: 24, z: 41.65}
           focalDistanceMm: 0
           lasers:

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar128E4XHighRes.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar128E4XHighRes.prefab
@@ -95,7 +95,7 @@ GameObject:
   - component: {fileID: 2398431948632788025}
   - component: {fileID: 3512952426893214564}
   m_Layer: 0
-  m_Name: HesaiPandar128E4X
+  m_Name: HesaiPandar128E4XHighRes
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -182,7 +182,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AutomaticCaptureHz: 10
-  modelPreset: 11
+  modelPreset: 12
   returnMode: 16777220
   applyDistanceGaussianNoise: 1
   applyAngularGaussianNoise: 1
@@ -203,40 +203,12 @@ MonoBehaviour:
   references:
     version: 1
     00000000:
-      type: {class: LaserBasedRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
+      type: {class: HesaiPandar128E4XHighResLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
         laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 88.33, z: 0}
           focalDistanceMm: 0
           lasers:
-          - horizontalAngularOffsetDeg: 0.186
-            verticalAngularOffsetDeg: -14.985
-            verticalLinearOffsetMm: 0
-            ringId: 1
-            timeOffset: 0.048963
-            minRange: 0.3
-            maxRange: 60
-          - horizontalAngularOffsetDeg: 0.185
-            verticalAngularOffsetDeg: -13.283
-            verticalLinearOffsetMm: 0
-            ringId: 2
-            timeOffset: 0.042674
-            minRange: 0.3
-            maxRange: 80
-          - horizontalAngularOffsetDeg: 1.335
-            verticalAngularOffsetDeg: -11.758
-            verticalLinearOffsetMm: 0
-            ringId: 3
-            timeOffset: 0.036385
-            minRange: 0.3
-            maxRange: 80
-          - horizontalAngularOffsetDeg: 1.343
-            verticalAngularOffsetDeg: -10.483
-            verticalLinearOffsetMm: 0
-            ringId: 4
-            timeOffset: 0.030096
-            minRange: 0.3
-            maxRange: 80
           - horizontalAngularOffsetDeg: 0.148
             verticalAngularOffsetDeg: -9.836
             verticalLinearOffsetMm: 0
@@ -263,34 +235,6 @@ MonoBehaviour:
             verticalLinearOffsetMm: 0
             ringId: 8
             timeOffset: 0.002318
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 1.335
-            verticalAngularOffsetDeg: -7.462
-            verticalLinearOffsetMm: 0
-            ringId: 9
-            timeOffset: 0.048963
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 1.336
-            verticalAngularOffsetDeg: -7.115
-            verticalLinearOffsetMm: 0
-            ringId: 10
-            timeOffset: 0.042674
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 1.337
-            verticalAngularOffsetDeg: -6.767
-            verticalLinearOffsetMm: 0
-            ringId: 11
-            timeOffset: 0.036385
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 1.338
-            verticalAngularOffsetDeg: -6.416
-            verticalLinearOffsetMm: 0
-            ringId: 12
-            timeOffset: 0.030096
             minRange: 0.3
             maxRange: 100
           - horizontalAngularOffsetDeg: 1.339
@@ -321,34 +265,6 @@ MonoBehaviour:
             timeOffset: 0.002318
             minRange: 0.3
             maxRange: 100
-          - horizontalAngularOffsetDeg: 0.128
-            verticalAngularOffsetDeg: -4.643
-            verticalLinearOffsetMm: 0
-            ringId: 17
-            timeOffset: 0.048963
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 0.128
-            verticalAngularOffsetDeg: -4.282
-            verticalLinearOffsetMm: 0
-            ringId: 18
-            timeOffset: 0.042674
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 0.127
-            verticalAngularOffsetDeg: -3.921
-            verticalLinearOffsetMm: 0
-            ringId: 19
-            timeOffset: 0.036385
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 0.127
-            verticalAngularOffsetDeg: -3.558
-            verticalLinearOffsetMm: 0
-            ringId: 20
-            timeOffset: 0.030096
-            minRange: 0.3
-            maxRange: 100
           - horizontalAngularOffsetDeg: 0.107
             verticalAngularOffsetDeg: -3.194
             verticalLinearOffsetMm: 0
@@ -375,6 +291,678 @@ MonoBehaviour:
             verticalLinearOffsetMm: 0
             ringId: 24
             timeOffset: 0.002318
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: -3.118
+            verticalAngularOffsetDeg: -1.974
+            verticalLinearOffsetMm: 0
+            ringId: 25
+            timeOffset: 0
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 1.315
+            verticalAngularOffsetDeg: -1.854
+            verticalLinearOffsetMm: 0
+            ringId: 26
+            timeOffset: 0.018867
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 4.529
+            verticalAngularOffsetDeg: -1.729
+            verticalLinearOffsetMm: 0
+            ringId: 27
+            timeOffset: 0.012578
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: -3.121
+            verticalAngularOffsetDeg: -1.609
+            verticalLinearOffsetMm: 0
+            ringId: 28
+            timeOffset: 0.018867
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 1.316
+            verticalAngularOffsetDeg: -1.487
+            verticalLinearOffsetMm: 0
+            ringId: 29
+            timeOffset: 0
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 4.532
+            verticalAngularOffsetDeg: -1.362
+            verticalLinearOffsetMm: 0
+            ringId: 30
+            timeOffset: 0.006289
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: -3.124
+            verticalAngularOffsetDeg: -1.242
+            verticalLinearOffsetMm: 0
+            ringId: 31
+            timeOffset: 0.016549
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 1.317
+            verticalAngularOffsetDeg: -1.12
+            verticalLinearOffsetMm: 0
+            ringId: 32
+            timeOffset: 0.01026
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 4.536
+            verticalAngularOffsetDeg: -0.995
+            verticalLinearOffsetMm: 0
+            ringId: 33
+            timeOffset: 0.016549
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: -3.127
+            verticalAngularOffsetDeg: -0.875
+            verticalLinearOffsetMm: 0
+            ringId: 34
+            timeOffset: 0.01026
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 1.317
+            verticalAngularOffsetDeg: -0.75
+            verticalLinearOffsetMm: 0
+            ringId: 35
+            timeOffset: 0.012578
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 4.539
+            verticalAngularOffsetDeg: -0.625
+            verticalLinearOffsetMm: 0
+            ringId: 36
+            timeOffset: 0.003971
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: -3.13
+            verticalAngularOffsetDeg: -0.5
+            verticalLinearOffsetMm: 0
+            ringId: 37
+            timeOffset: 0.003971
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 1.318
+            verticalAngularOffsetDeg: -0.375
+            verticalLinearOffsetMm: 0
+            ringId: 38
+            timeOffset: 0.006289
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 4.542
+            verticalAngularOffsetDeg: -0.25
+            verticalLinearOffsetMm: 0
+            ringId: 39
+            timeOffset: 0.022838
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: -3.133
+            verticalAngularOffsetDeg: -0.125
+            verticalLinearOffsetMm: 0
+            ringId: 40
+            timeOffset: 0.022838
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 0.103
+            verticalAngularOffsetDeg: 0
+            verticalLinearOffsetMm: 0
+            ringId: 41
+            timeOffset: 0.016549
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 2.935
+            verticalAngularOffsetDeg: 0.125
+            verticalLinearOffsetMm: 0
+            ringId: 42
+            timeOffset: 0.018867
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: -1.517
+            verticalAngularOffsetDeg: 0.25
+            verticalLinearOffsetMm: 0
+            ringId: 43
+            timeOffset: 0
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 0.103
+            verticalAngularOffsetDeg: 0.375
+            verticalLinearOffsetMm: 0
+            ringId: 44
+            timeOffset: 0.01026
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 2.937
+            verticalAngularOffsetDeg: 0.5
+            verticalLinearOffsetMm: 0
+            ringId: 45
+            timeOffset: 0.012578
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: -1.519
+            verticalAngularOffsetDeg: 0.626
+            verticalLinearOffsetMm: 0
+            ringId: 46
+            timeOffset: 0.018867
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 0.103
+            verticalAngularOffsetDeg: 0.751
+            verticalLinearOffsetMm: 0
+            ringId: 47
+            timeOffset: 0.003971
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 2.939
+            verticalAngularOffsetDeg: 0.876
+            verticalLinearOffsetMm: 0
+            ringId: 48
+            timeOffset: 0.006289
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: -1.52
+            verticalAngularOffsetDeg: 1.001
+            verticalLinearOffsetMm: 0
+            ringId: 49
+            timeOffset: 0.012578
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 0.103
+            verticalAngularOffsetDeg: 1.126
+            verticalLinearOffsetMm: 0
+            ringId: 50
+            timeOffset: 0.022838
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 2.941
+            verticalAngularOffsetDeg: 1.251
+            verticalLinearOffsetMm: 0
+            ringId: 51
+            timeOffset: 0.016549
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: -1.521
+            verticalAngularOffsetDeg: 1.377
+            verticalLinearOffsetMm: 0
+            ringId: 52
+            timeOffset: 0.006289
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 0.102
+            verticalAngularOffsetDeg: 1.502
+            verticalLinearOffsetMm: 0
+            ringId: 53
+            timeOffset: 0
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 2.943
+            verticalAngularOffsetDeg: 1.627
+            verticalLinearOffsetMm: 0
+            ringId: 54
+            timeOffset: 0.01026
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: -1.523
+            verticalAngularOffsetDeg: 1.751
+            verticalLinearOffsetMm: 0
+            ringId: 55
+            timeOffset: 0.016549
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 0.102
+            verticalAngularOffsetDeg: 1.876
+            verticalLinearOffsetMm: 0
+            ringId: 56
+            timeOffset: 0.018867
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 2.945
+            verticalAngularOffsetDeg: 2.001
+            verticalLinearOffsetMm: 0
+            ringId: 57
+            timeOffset: 0.003971
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: -1.524
+            verticalAngularOffsetDeg: 2.126
+            verticalLinearOffsetMm: 0
+            ringId: 58
+            timeOffset: 0.01026
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 0.102
+            verticalAngularOffsetDeg: 2.251
+            verticalLinearOffsetMm: 0
+            ringId: 59
+            timeOffset: 0.012578
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 2.946
+            verticalAngularOffsetDeg: 2.376
+            verticalLinearOffsetMm: 0
+            ringId: 60
+            timeOffset: 0.022838
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: -1.526
+            verticalAngularOffsetDeg: 2.501
+            verticalLinearOffsetMm: 0
+            ringId: 61
+            timeOffset: 0.003971
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 0.102
+            verticalAngularOffsetDeg: 2.626
+            verticalLinearOffsetMm: 0
+            ringId: 62
+            timeOffset: 0.006289
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 2.948
+            verticalAngularOffsetDeg: 2.751
+            verticalLinearOffsetMm: 0
+            ringId: 63
+            timeOffset: 0
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: -1.526
+            verticalAngularOffsetDeg: 2.876
+            verticalLinearOffsetMm: 0
+            ringId: 64
+            timeOffset: 0.022838
+            minRange: 0.3
+            maxRange: 200
+          - horizontalAngularOffsetDeg: 1.324
+            verticalAngularOffsetDeg: 3.001
+            verticalLinearOffsetMm: 0
+            ringId: 65
+            timeOffset: 0.016549
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 4.57
+            verticalAngularOffsetDeg: 3.126
+            verticalLinearOffsetMm: 0
+            ringId: 66
+            timeOffset: 0.018867
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: -3.155
+            verticalAngularOffsetDeg: 3.251
+            verticalLinearOffsetMm: 0
+            ringId: 67
+            timeOffset: 0
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 1.325
+            verticalAngularOffsetDeg: 3.376
+            verticalLinearOffsetMm: 0
+            ringId: 68
+            timeOffset: 0.01026
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 4.573
+            verticalAngularOffsetDeg: 3.501
+            verticalLinearOffsetMm: 0
+            ringId: 69
+            timeOffset: 0.012578
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: -3.157
+            verticalAngularOffsetDeg: 3.626
+            verticalLinearOffsetMm: 0
+            ringId: 70
+            timeOffset: 0.018867
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 1.326
+            verticalAngularOffsetDeg: 3.751
+            verticalLinearOffsetMm: 0
+            ringId: 71
+            timeOffset: 0.003971
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 4.575
+            verticalAngularOffsetDeg: 3.876
+            verticalLinearOffsetMm: 0
+            ringId: 72
+            timeOffset: 0.006289
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: -3.159
+            verticalAngularOffsetDeg: 4.001
+            verticalLinearOffsetMm: 0
+            ringId: 73
+            timeOffset: 0.012578
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 1.326
+            verticalAngularOffsetDeg: 4.126
+            verticalLinearOffsetMm: 0
+            ringId: 74
+            timeOffset: 0.022838
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 4.578
+            verticalAngularOffsetDeg: 4.25
+            verticalLinearOffsetMm: 0
+            ringId: 75
+            timeOffset: 0.016549
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: -3.161
+            verticalAngularOffsetDeg: 4.375
+            verticalLinearOffsetMm: 0
+            ringId: 76
+            timeOffset: 0.006289
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 1.327
+            verticalAngularOffsetDeg: 4.501
+            verticalLinearOffsetMm: 0
+            ringId: 77
+            timeOffset: 0
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 4.581
+            verticalAngularOffsetDeg: 4.626
+            verticalLinearOffsetMm: 0
+            ringId: 78
+            timeOffset: 0.01026
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: -3.163
+            verticalAngularOffsetDeg: 4.751
+            verticalLinearOffsetMm: 0
+            ringId: 79
+            timeOffset: 0.016549
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 1.328
+            verticalAngularOffsetDeg: 4.876
+            verticalLinearOffsetMm: 0
+            ringId: 80
+            timeOffset: 0.018867
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 4.583
+            verticalAngularOffsetDeg: 5.001
+            verticalLinearOffsetMm: 0
+            ringId: 81
+            timeOffset: 0.003971
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: -3.165
+            verticalAngularOffsetDeg: 5.126
+            verticalLinearOffsetMm: 0
+            ringId: 82
+            timeOffset: 0.01026
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 1.329
+            verticalAngularOffsetDeg: 5.252
+            verticalLinearOffsetMm: 0
+            ringId: 83
+            timeOffset: 0.012578
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 4.586
+            verticalAngularOffsetDeg: 5.377
+            verticalLinearOffsetMm: 0
+            ringId: 84
+            timeOffset: 0.022838
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: -3.167
+            verticalAngularOffsetDeg: 5.502
+            verticalLinearOffsetMm: 0
+            ringId: 85
+            timeOffset: 0.003971
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 1.329
+            verticalAngularOffsetDeg: 5.626
+            verticalLinearOffsetMm: 0
+            ringId: 86
+            timeOffset: 0.006289
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 4.588
+            verticalAngularOffsetDeg: 5.752
+            verticalLinearOffsetMm: 0
+            ringId: 87
+            timeOffset: 0
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: -3.168
+            verticalAngularOffsetDeg: 5.877
+            verticalLinearOffsetMm: 0
+            ringId: 88
+            timeOffset: 0.022838
+            minRange: 0.3
+            maxRange: 140
+          - horizontalAngularOffsetDeg: 0.104
+            verticalAngularOffsetDeg: 7.507
+            verticalLinearOffsetMm: 0
+            ringId: 93
+            timeOffset: 0.021185
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 0.104
+            verticalAngularOffsetDeg: 7.882
+            verticalLinearOffsetMm: 0
+            ringId: 94
+            timeOffset: 0.014896
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 0.104
+            verticalAngularOffsetDeg: 8.257
+            verticalLinearOffsetMm: 0
+            ringId: 95
+            timeOffset: 0.008607
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 0.104
+            verticalAngularOffsetDeg: 8.632
+            verticalLinearOffsetMm: 0
+            ringId: 96
+            timeOffset: 0.002318
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 1.34
+            verticalAngularOffsetDeg: 10.493
+            verticalLinearOffsetMm: 0
+            ringId: 101
+            timeOffset: 0.021185
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 1.341
+            verticalAngularOffsetDeg: 10.864
+            verticalLinearOffsetMm: 0
+            ringId: 102
+            timeOffset: 0.014896
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 1.341
+            verticalAngularOffsetDeg: 11.234
+            verticalLinearOffsetMm: 0
+            ringId: 103
+            timeOffset: 0.008607
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 1.342
+            verticalAngularOffsetDeg: 11.603
+            verticalLinearOffsetMm: 0
+            ringId: 104
+            timeOffset: 0.002318
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 0.13
+            verticalAngularOffsetDeg: 13.439
+            verticalLinearOffsetMm: 0
+            ringId: 109
+            timeOffset: 0.021185
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 0.131
+            verticalAngularOffsetDeg: 13.803
+            verticalLinearOffsetMm: 0
+            ringId: 110
+            timeOffset: 0.014896
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 0.131
+            verticalAngularOffsetDeg: 14.164
+            verticalLinearOffsetMm: 0
+            ringId: 111
+            timeOffset: 0.008607
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 0.132
+            verticalAngularOffsetDeg: 14.525
+            verticalLinearOffsetMm: 0
+            ringId: 112
+            timeOffset: 0.002318
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 1.386
+            verticalAngularOffsetDeg: 16.299
+            verticalLinearOffsetMm: 0
+            ringId: 117
+            timeOffset: 0.021185
+            minRange: 0.3
+            maxRange: 80
+          - horizontalAngularOffsetDeg: 1.386
+            verticalAngularOffsetDeg: 16.651
+            verticalLinearOffsetMm: 0
+            ringId: 118
+            timeOffset: 0.014896
+            minRange: 0.3
+            maxRange: 80
+          - horizontalAngularOffsetDeg: 1.387
+            verticalAngularOffsetDeg: 17
+            verticalLinearOffsetMm: 0
+            ringId: 119
+            timeOffset: 0.008607
+            minRange: 0.3
+            maxRange: 80
+          - horizontalAngularOffsetDeg: 1.387
+            verticalAngularOffsetDeg: 17.347
+            verticalLinearOffsetMm: 0
+            ringId: 120
+            timeOffset: 0.002318
+            minRange: 0.3
+            maxRange: 80
+          - horizontalAngularOffsetDeg: 1.388
+            verticalAngularOffsetDeg: 20.376
+            verticalLinearOffsetMm: 0
+            ringId: 125
+            timeOffset: 0.021185
+            minRange: 0.3
+            maxRange: 80
+          - horizontalAngularOffsetDeg: 1.408
+            verticalAngularOffsetDeg: 21.653
+            verticalLinearOffsetMm: 0
+            ringId: 126
+            timeOffset: 0.014896
+            minRange: 0.3
+            maxRange: 50
+          - horizontalAngularOffsetDeg: 0.196
+            verticalAngularOffsetDeg: 23.044
+            verticalLinearOffsetMm: 0
+            ringId: 127
+            timeOffset: 0.008607
+            minRange: 0.3
+            maxRange: 40
+          - horizontalAngularOffsetDeg: 0.286
+            verticalAngularOffsetDeg: 24.765
+            verticalLinearOffsetMm: 0
+            ringId: 128
+            timeOffset: 0.002318
+            minRange: 0.3
+            maxRange: 30
+          - horizontalAngularOffsetDeg: 0.186
+            verticalAngularOffsetDeg: -14.985
+            verticalLinearOffsetMm: 0
+            ringId: 1
+            timeOffset: 0.048963
+            minRange: 0.3
+            maxRange: 60
+          - horizontalAngularOffsetDeg: 0.185
+            verticalAngularOffsetDeg: -13.283
+            verticalLinearOffsetMm: 0
+            ringId: 2
+            timeOffset: 0.042674
+            minRange: 0.3
+            maxRange: 80
+          - horizontalAngularOffsetDeg: 1.335
+            verticalAngularOffsetDeg: -11.758
+            verticalLinearOffsetMm: 0
+            ringId: 3
+            timeOffset: 0.036385
+            minRange: 0.3
+            maxRange: 80
+          - horizontalAngularOffsetDeg: 1.343
+            verticalAngularOffsetDeg: -10.483
+            verticalLinearOffsetMm: 0
+            ringId: 4
+            timeOffset: 0.030096
+            minRange: 0.3
+            maxRange: 80
+          - horizontalAngularOffsetDeg: 1.335
+            verticalAngularOffsetDeg: -7.462
+            verticalLinearOffsetMm: 0
+            ringId: 9
+            timeOffset: 0.048963
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 1.336
+            verticalAngularOffsetDeg: -7.115
+            verticalLinearOffsetMm: 0
+            ringId: 10
+            timeOffset: 0.042674
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 1.337
+            verticalAngularOffsetDeg: -6.767
+            verticalLinearOffsetMm: 0
+            ringId: 11
+            timeOffset: 0.036385
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 1.338
+            verticalAngularOffsetDeg: -6.416
+            verticalLinearOffsetMm: 0
+            ringId: 12
+            timeOffset: 0.030096
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 0.128
+            verticalAngularOffsetDeg: -4.643
+            verticalLinearOffsetMm: 0
+            ringId: 17
+            timeOffset: 0.048963
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 0.128
+            verticalAngularOffsetDeg: -4.282
+            verticalLinearOffsetMm: 0
+            ringId: 18
+            timeOffset: 0.042674
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 0.127
+            verticalAngularOffsetDeg: -3.921
+            verticalLinearOffsetMm: 0
+            ringId: 19
+            timeOffset: 0.036385
+            minRange: 0.3
+            maxRange: 100
+          - horizontalAngularOffsetDeg: 0.127
+            verticalAngularOffsetDeg: -3.558
+            verticalLinearOffsetMm: 0
+            ringId: 20
+            timeOffset: 0.030096
             minRange: 0.3
             maxRange: 100
           - horizontalAngularOffsetDeg: -3.118
@@ -853,34 +1441,6 @@ MonoBehaviour:
             timeOffset: 0.030096
             minRange: 0.3
             maxRange: 100
-          - horizontalAngularOffsetDeg: 0.104
-            verticalAngularOffsetDeg: 7.507
-            verticalLinearOffsetMm: 0
-            ringId: 93
-            timeOffset: 0.021185
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 0.104
-            verticalAngularOffsetDeg: 7.882
-            verticalLinearOffsetMm: 0
-            ringId: 94
-            timeOffset: 0.014896
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 0.104
-            verticalAngularOffsetDeg: 8.257
-            verticalLinearOffsetMm: 0
-            ringId: 95
-            timeOffset: 0.008607
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 0.104
-            verticalAngularOffsetDeg: 8.632
-            verticalLinearOffsetMm: 0
-            ringId: 96
-            timeOffset: 0.002318
-            minRange: 0.3
-            maxRange: 100
           - horizontalAngularOffsetDeg: 1.337
             verticalAngularOffsetDeg: 9.003
             verticalLinearOffsetMm: 0
@@ -907,34 +1467,6 @@ MonoBehaviour:
             verticalLinearOffsetMm: 0
             ringId: 100
             timeOffset: 0.030096
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 1.34
-            verticalAngularOffsetDeg: 10.493
-            verticalLinearOffsetMm: 0
-            ringId: 101
-            timeOffset: 0.021185
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 1.341
-            verticalAngularOffsetDeg: 10.864
-            verticalLinearOffsetMm: 0
-            ringId: 102
-            timeOffset: 0.014896
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 1.341
-            verticalAngularOffsetDeg: 11.234
-            verticalLinearOffsetMm: 0
-            ringId: 103
-            timeOffset: 0.008607
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 1.342
-            verticalAngularOffsetDeg: 11.603
-            verticalLinearOffsetMm: 0
-            ringId: 104
-            timeOffset: 0.002318
             minRange: 0.3
             maxRange: 100
           - horizontalAngularOffsetDeg: 0.108
@@ -965,34 +1497,6 @@ MonoBehaviour:
             timeOffset: 0.030096
             minRange: 0.3
             maxRange: 100
-          - horizontalAngularOffsetDeg: 0.13
-            verticalAngularOffsetDeg: 13.439
-            verticalLinearOffsetMm: 0
-            ringId: 109
-            timeOffset: 0.021185
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 0.131
-            verticalAngularOffsetDeg: 13.803
-            verticalLinearOffsetMm: 0
-            ringId: 110
-            timeOffset: 0.014896
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 0.131
-            verticalAngularOffsetDeg: 14.164
-            verticalLinearOffsetMm: 0
-            ringId: 111
-            timeOffset: 0.008607
-            minRange: 0.3
-            maxRange: 100
-          - horizontalAngularOffsetDeg: 0.132
-            verticalAngularOffsetDeg: 14.525
-            verticalLinearOffsetMm: 0
-            ringId: 112
-            timeOffset: 0.002318
-            minRange: 0.3
-            maxRange: 100
           - horizontalAngularOffsetDeg: 1.384
             verticalAngularOffsetDeg: 14.879
             verticalLinearOffsetMm: 0
@@ -1019,34 +1523,6 @@ MonoBehaviour:
             verticalLinearOffsetMm: 0
             ringId: 116
             timeOffset: 0.030096
-            minRange: 0.3
-            maxRange: 80
-          - horizontalAngularOffsetDeg: 1.386
-            verticalAngularOffsetDeg: 16.299
-            verticalLinearOffsetMm: 0
-            ringId: 117
-            timeOffset: 0.021185
-            minRange: 0.3
-            maxRange: 80
-          - horizontalAngularOffsetDeg: 1.386
-            verticalAngularOffsetDeg: 16.651
-            verticalLinearOffsetMm: 0
-            ringId: 118
-            timeOffset: 0.014896
-            minRange: 0.3
-            maxRange: 80
-          - horizontalAngularOffsetDeg: 1.387
-            verticalAngularOffsetDeg: 17
-            verticalLinearOffsetMm: 0
-            ringId: 119
-            timeOffset: 0.008607
-            minRange: 0.3
-            maxRange: 80
-          - horizontalAngularOffsetDeg: 1.387
-            verticalAngularOffsetDeg: 17.347
-            verticalLinearOffsetMm: 0
-            ringId: 120
-            timeOffset: 0.002318
             minRange: 0.3
             maxRange: 80
           - horizontalAngularOffsetDeg: 0.151
@@ -1077,34 +1553,6 @@ MonoBehaviour:
             timeOffset: 0.030096
             minRange: 0.3
             maxRange: 80
-          - horizontalAngularOffsetDeg: 1.388
-            verticalAngularOffsetDeg: 20.376
-            verticalLinearOffsetMm: 0
-            ringId: 125
-            timeOffset: 0.021185
-            minRange: 0.3
-            maxRange: 80
-          - horizontalAngularOffsetDeg: 1.408
-            verticalAngularOffsetDeg: 21.653
-            verticalLinearOffsetMm: 0
-            ringId: 126
-            timeOffset: 0.014896
-            minRange: 0.3
-            maxRange: 50
-          - horizontalAngularOffsetDeg: 0.196
-            verticalAngularOffsetDeg: 23.044
-            verticalLinearOffsetMm: 0
-            ringId: 127
-            timeOffset: 0.008607
-            minRange: 0.3
-            maxRange: 40
-          - horizontalAngularOffsetDeg: 0.286
-            verticalAngularOffsetDeg: 24.765
-            verticalLinearOffsetMm: 0
-            ringId: 128
-            timeOffset: 0.002318
-            minRange: 0.3
-            maxRange: 30
         horizontalResolution: 0.2
         minHAngle: 0
         maxHAngle: 360

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar128E4XHighRes.prefab.meta
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar128E4XHighRes.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d7db1357a724e60fcaf927dd10adafd2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar40P.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandar40P.prefab
@@ -469,7 +469,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &7675420128049466981
 MonoBehaviour:
@@ -531,7 +531,7 @@ MonoBehaviour:
     00000000:
       type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
-        _laserArray:
+        laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 47.7, z: 0}
           focalDistanceMm: 0
           lasers:

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarQT64.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarQT64.prefab
@@ -372,7 +372,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &1430391258634731476
 MonoBehaviour:
@@ -434,7 +434,7 @@ MonoBehaviour:
     00000000:
       type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
-        _laserArray:
+        laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 50.4, z: 0}
           focalDistanceMm: 29.8
           lasers:

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarXT32.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiPandarXT32.prefab
@@ -302,7 +302,7 @@ MonoBehaviour:
     00000000:
       type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
-        _laserArray:
+        laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 46.4, z: 0}
           focalDistanceMm: 31.5
           lasers:

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiQT128C2X.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/HesaiQT128C2X.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &1429064023790827067
 MonoBehaviour:
@@ -123,7 +123,7 @@ MonoBehaviour:
     00000000:
       type: {class: HesaiQT128C2XLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
-        _laserArray:
+        laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 58.2, z: 0}
           focalDistanceMm: 35.4
           lasers:

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/OusterOS1-64.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/OusterOS1-64.prefab
@@ -122,7 +122,7 @@ MonoBehaviour:
     00000000:
       type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
-        _laserArray:
+        laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 36.18, z: 0}
           focalDistanceMm: 12.163
           lasers:

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP16.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &4572956135196922574
 MonoBehaviour:
@@ -123,7 +123,7 @@ MonoBehaviour:
     00000000:
       type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
-        _laserArray:
+        laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 37.7, z: 0}
           focalDistanceMm: 0
           lasers:

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP32C.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLP32C.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   - topic: lidar/pointcloud_ex
     publish: 1
     fieldsPreset: 2
-    fields: 01000000030000000c0000000b0000000a00000009000000080000000e000000
+    fields: 01000000030000000c0000000b000000090000000a000000080000000e000000
   radarScanPublishers: []
 --- !u!114 &6422033487030486066
 MonoBehaviour:
@@ -123,7 +123,7 @@ MonoBehaviour:
     00000000:
       type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
-        _laserArray:
+        laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 37.34, z: 0}
           focalDistanceMm: 42.4
           lasers:

--- a/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLS128.prefab
+++ b/Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/VelodyneVLS128.prefab
@@ -531,7 +531,7 @@ MonoBehaviour:
     00000000:
       type: {class: UniformRangeLidarConfiguration, ns: RGLUnityPlugin, asm: AWSIM}
       data:
-        _laserArray:
+        laserArray:
           centerOfMeasurementLinearOffsetMm: {x: 0, y: 66.11, z: 0}
           focalDistanceMm: 58.63
           lasers:

--- a/Assets/RGLUnityPlugin/Scripts/LidarModels/LaserArray.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarModels/LaserArray.cs
@@ -35,6 +35,7 @@ namespace RGLUnityPlugin
         //             |
         // Note: It is not always lay on the axis of symmetry of the device (e.g., hybrid solid-state LIDARs)
         // This offset is not considered when generating laser poses. To be applied manually when setting the pose of the lidar (in RGL).
+        [Tooltip("Offset from the game object origin to the sensor origin.")]
         public Vector3 centerOfMeasurementLinearOffsetMm;
 
         //             |           /
@@ -49,7 +50,7 @@ namespace RGLUnityPlugin
         //             .       .
         //             .<----->.
         //           this distance
-        // Distance from the sensor center to the focal point where all laser beams intersect.
+        [Tooltip("Distance from the sensor center to the focal point where all laser beams intersect.")]
         public float focalDistanceMm;
 
         /// <summary>

--- a/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfiguration.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfiguration.cs
@@ -160,7 +160,11 @@ namespace RGLUnityPlugin
     /// It allows the definition of the lidar with different ranges for each laser (channel).
     /// </summary>
     [Serializable]
-    public class LaserBasedRangeLidarConfiguration : BaseLidarConfiguration { }
+    public class LaserBasedRangeLidarConfiguration : BaseLidarConfiguration
+    {
+        [Tooltip("To modify LiDAR range, use LaserArray/Lasers")]
+        public EmptyStruct rangeModificationTooltip;
+    }
 
     /// <summary>
     /// Lidar configuration for uniformly distributed rays along the horizontal axis with a uniform range for all the rays.
@@ -195,7 +199,7 @@ namespace RGLUnityPlugin
     /// It contains properties and ray-generating methods specific to this lidar.
     /// </summary>
     [Serializable]
-    public class HesaiAT128LidarConfiguration : BaseLidarConfiguration
+    public class HesaiAT128LidarConfiguration : LaserBasedRangeLidarConfiguration
     {
         public override Vector2[] GetRayRanges()
         {
@@ -234,7 +238,7 @@ namespace RGLUnityPlugin
     /// It contains properties and ray-generating methods specific to this lidar.
     /// </summary>
     [Serializable]
-    public class HesaiQT128C2XLidarConfiguration : BaseLidarConfiguration
+    public class HesaiQT128C2XLidarConfiguration : LaserBasedRangeLidarConfiguration
     {
         private static int hesaiQT128LasersBankLength = 32;
 
@@ -280,7 +284,7 @@ namespace RGLUnityPlugin
     /// It contains properties and ray-generating methods specific to this lidar.
     /// </summary>
     [Serializable]
-    public class HesaiPandar128E4XLidarConfiguration : BaseLidarConfiguration
+    public class HesaiPandar128E4XLidarConfiguration : LaserBasedRangeLidarConfiguration
     {
         // High resolution mode changes laser array
         public override LaserArray laserArray

--- a/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfiguration.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfiguration.cs
@@ -26,7 +26,9 @@ namespace RGLUnityPlugin
     [Serializable]
     public abstract class BaseLidarConfiguration
     {
-        [Tooltip("Geometry description of lidar array")]
+        [Tooltip("List of lasers constituting this LiDAR.\n" +
+                 "Note: For some (advanced) LiDARs, it may contain duplicates of lasers if one scan consist of multiple firing sequences.\n" +
+                 "Note2: Laser's range is considered for non-uniform range LiDARs only (if configuration has no global range setting).")]
         public LaserArray laserArray;
 
         [Tooltip("The horizontal resolution of laser array firings (in degrees)")]

--- a/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfigurationLibrary.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarConfigurationLibrary.cs
@@ -176,18 +176,29 @@ namespace RGLUnityPlugin
                     verticalBeamDivergence = 0.13f, // Not specified in manual
                 }},
 
-                {LidarModel.HesaiPandar128E4X, () => new HesaiPandar128E4XLidarConfiguration()
+                {LidarModel.HesaiPandar128E4X, () => new LaserBasedRangeLidarConfiguration()
                 {
                     laserArray = LaserArrayLibrary.HesaiPandar128E4X,
-                    horizontalResolution = 0.2f,  // resolution for standard mode
-                                                  // if high resolution enabled, high-res channels will have half of this resolution
-                    laserArrayCycleTime = 0.055556f,  // time for standard mode
+                    horizontalResolution = 0.2f,
+                    laserArrayCycleTime = 0.055556f,
                     minHAngle = 0.0f,
                     maxHAngle = 360.0f,
                     noiseParams = LidarNoiseParams.TypicalNoiseParams,
                     horizontalBeamDivergence = 0.13f, // Not specified in manual
                     verticalBeamDivergence = 0.13f, // Not specified in manual
-                    highResolutionModeEnabled = false,
+                }},
+
+                {LidarModel.HesaiPandar128E4XHighRes, () => new HesaiPandar128E4XHighResLidarConfiguration()
+                {
+                    laserArray = LaserArrayLibrary.HesaiPandar128E4XHighRes,
+                    horizontalResolution = 0.2f,  // same as for standard mode but
+                                                  // high-res channels will have half of this resolution
+                    laserArrayCycleTime = 0.055556f,
+                    minHAngle = 0.0f,
+                    maxHAngle = 360.0f,
+                    noiseParams = LidarNoiseParams.TypicalNoiseParams,
+                    horizontalBeamDivergence = 0.13f, // Not specified in manual
+                    verticalBeamDivergence = 0.13f, // Not specified in manual
                 }},
             };
     }

--- a/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarModels.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarModels/LidarModels.cs
@@ -27,6 +27,7 @@ namespace RGLUnityPlugin
         HesaiAT128E2X,
         HesaiPandarXT32,
         HesaiQT128C2X,
-        HesaiPandar128E4X
+        HesaiPandar128E4X,
+        HesaiPandar128E4XHighRes
     }
 }

--- a/Assets/RGLUnityPlugin/Scripts/LidarUdpPublisher.cs
+++ b/Assets/RGLUnityPlugin/Scripts/LidarUdpPublisher.cs
@@ -66,6 +66,7 @@ namespace RGLUnityPlugin
             { LidarModel.HesaiPandarQT, RGLLidarModel.RGL_HESAI_PANDAR_QT64 },
             { LidarModel.HesaiQT128C2X, RGLLidarModel.RGL_HESAI_QT128C2X },
             { LidarModel.HesaiPandar128E4X, RGLLidarModel.RGL_HESAI_PANDAR_128E4X },
+            { LidarModel.HesaiPandar128E4XHighRes, RGLLidarModel.RGL_HESAI_PANDAR_128E4X },
             { LidarModel.HesaiPandarXT32, RGLLidarModel.RGL_HESAI_PANDAR_XT32 }
         };
 
@@ -90,6 +91,9 @@ namespace RGLUnityPlugin
             { LidarModel.HesaiPandar128E4X, new List<RGLReturnMode>()
                 { RGLReturnMode.SingleReturnFirst, RGLReturnMode.SingleReturnStrongest, RGLReturnMode.SingleReturnLast,
                   RGLReturnMode.DualReturnLastStrongest, RGLReturnMode.DualReturnFirstLast, RGLReturnMode.DualReturnFirstStrongest } },
+            { LidarModel.HesaiPandar128E4XHighRes, new List<RGLReturnMode>() // same as for HesaiPandar128E4X
+                { RGLReturnMode.SingleReturnFirst, RGLReturnMode.SingleReturnStrongest, RGLReturnMode.SingleReturnLast,
+                  RGLReturnMode.DualReturnLastStrongest, RGLReturnMode.DualReturnFirstLast, RGLReturnMode.DualReturnFirstStrongest } },
             { LidarModel.HesaiPandarXT32, new List<RGLReturnMode>()
                 { RGLReturnMode.SingleReturnStrongest, RGLReturnMode.SingleReturnLast, RGLReturnMode.DualReturnLastStrongest } },
         };
@@ -107,7 +111,8 @@ namespace RGLUnityPlugin
                    model == LidarModel.HesaiPandarQT ||
                    model == LidarModel.HesaiPandarXT32 ||
                    model == LidarModel.HesaiQT128C2X ||
-                   model == LidarModel.HesaiPandar128E4X;
+                   model == LidarModel.HesaiPandar128E4X ||
+                   model == LidarModel.HesaiPandar128E4XHighRes;
         }
 
         // To be called when adding this component
@@ -305,13 +310,9 @@ namespace RGLUnityPlugin
             udpOptions += enableHesaiUpCloseBlockageDetection ? (UInt32)RGLUdpOptions.RGL_UDP_UP_CLOSE_BLOCKAGE_DETECTION : 0;
             udpOptions += enableHesaiPandarDriverCompatibilityForQt ? (UInt32)RGLUdpOptions.RGL_UDP_FIT_QT64_TO_HESAI_PANDAR_DRIVER : 0;
 
-            // Check if high resolution mode is enabled (available only on Hesai Pandar128E4X)
-            if (currentLidarModel == LidarModel.HesaiPandar128E4X)
+            if (currentLidarModel == LidarModel.HesaiPandar128E4XHighRes)
             {
-                if (((HesaiPandar128E4XLidarConfiguration)lidarSensor.configuration).highResolutionModeEnabled)
-                {
-                    udpOptions += (UInt32)RGLUdpOptions.RGL_UDP_HIGH_RESOLUTION_MODE;
-                }
+                udpOptions += (UInt32)RGLUdpOptions.RGL_UDP_HIGH_RESOLUTION_MODE;
             }
 
             return (RGLUdpOptions)udpOptions;

--- a/Assets/RGLUnityPlugin/Scripts/Utilities/InspectorUtilities.cs
+++ b/Assets/RGLUnityPlugin/Scripts/Utilities/InspectorUtilities.cs
@@ -1,0 +1,27 @@
+// Copyright 2022 Robotec.ai.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace RGLUnityPlugin
+{
+    /// <summary>
+    /// An empty struct that can be used as ToolTip attachment object.
+    /// Useful when you want to provide instructions in the Inspector.
+    /// </summary>
+    [Serializable]
+    public struct EmptyStruct
+    {
+    }
+}

--- a/Assets/RGLUnityPlugin/Scripts/Utilities/InspectorUtilities.cs.meta
+++ b/Assets/RGLUnityPlugin/Scripts/Utilities/InspectorUtilities.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 99d5d0bd7bc44b7798d1e75e58294311
+timeCreated: 1734353532

--- a/docs/Components/Sensors/LiDARSensor/LiDARSensor/index.md
+++ b/docs/Components/Sensors/LiDARSensor/LiDARSensor/index.md
@@ -39,18 +39,19 @@ Assets/AWSIM/Prefabs/Sensors/RobotecGPULidars/*
 
 The table of available prefabs can be found below:
 
-| LiDAR                 | Path                       | Appearance                                          |
-| :-------------------- | :-----------------------   | :------------------------------------------------   |
-| *HESAI Pandar40P*     | `HesaiPandar40P.prefab`    | <img src=imgs_prefabs/pandar40p.png width=150px>    |
-| *HESAI PandarQT64*    | `HesaiPandarQT64.prefab`   | <img src=imgs_prefabs/pandarqt.png width=150px>     |
-| *HESAI PandarXT32*    | `HesaiPandarXT32.prefab`   | <img src=imgs_prefabs/pandarxt32.png width=150px>   |
-| *HESAI QT128C2X*      | `HesaiQT128C2X.prefab`     | <img src=imgs_prefabs/qt1238c2x.png width=150px>    |
-| *HESAI Pandar128E4X*  | `HesaiPandar128E4X.prefab` | <img src=imgs_prefabs/pandar128e4x.png width=150px> |
-| *HESAI AT128 E2X*     | `HesaiAT128E2X.prefab`     | <img src=imgs_prefabs/at128e2x.png width=150px>     |
-| *Ouster OS1-64*       | `OusterOS1-64.prefab`      | <img src=imgs_prefabs/os1-64.png width=150px>       |
-| *Velodyne VLP-16*     | `VelodyneVLP16.prefab`     | <img src=imgs_prefabs/vlp16.png width=150px>        |
-| *Velodyne VLC-32C*    | `VelodyneVLP32C.prefab`    | <img src=imgs_prefabs/vlp32.png width=150px>        |
-| *Velodyne VLS-128-AP* | `VelodyneVLS128.prefab`    | <img src=imgs_prefabs/vls128.png width=150px>       |
+| LiDAR                       | Path                              | Appearance                                          |
+| :--------------------       | :-----------------------          | :------------------------------------------------   |
+| *HESAI Pandar40P*           | `HesaiPandar40P.prefab`           | <img src=imgs_prefabs/pandar40p.png width=150px>    |
+| *HESAI PandarQT64*          | `HesaiPandarQT64.prefab`          | <img src=imgs_prefabs/pandarqt.png width=150px>     |
+| *HESAI PandarXT32*          | `HesaiPandarXT32.prefab`          | <img src=imgs_prefabs/pandarxt32.png width=150px>   |
+| *HESAI QT128C2X*            | `HesaiQT128C2X.prefab`            | <img src=imgs_prefabs/qt1238c2x.png width=150px>    |
+| *HESAI Pandar128E4X*        | `HesaiPandar128E4X.prefab`        | <img src=imgs_prefabs/pandar128e4x.png width=150px> |
+| *HESAI Pandar128E4XHighRes* | `HesaiPandar128E4XHighRes.prefab` | <img src=imgs_prefabs/pandar128e4x.png width=150px> |
+| *HESAI AT128 E2X*           | `HesaiAT128E2X.prefab`            | <img src=imgs_prefabs/at128e2x.png width=150px>     |
+| *Ouster OS1-64*             | `OusterOS1-64.prefab`             | <img src=imgs_prefabs/os1-64.png width=150px>       |
+| *Velodyne VLP-16*           | `VelodyneVLP16.prefab`            | <img src=imgs_prefabs/vlp16.png width=150px>        |
+| *Velodyne VLC-32C*          | `VelodyneVLP32C.prefab`           | <img src=imgs_prefabs/vlp32.png width=150px>        |
+| *Velodyne VLS-128-AP*       | `VelodyneVLS128.prefab`           | <img src=imgs_prefabs/vls128.png width=150px>       |
 
 ### Link in the default Scene
 ![link](link.png)
@@ -137,11 +138,12 @@ horizontal and vertical beam divergence values (as they would be set to 0). Note
         - `Enable Restriction Randomizer` - enable/disable random periodic mode (default: `false`)
         - `Min Random Period` - lower bound of time period in seconds used in random mode
         - `Max Random Period` - upper bound of time period in seconds used in random mode
-
     - *Additional options (available for some Lidar Model Preset)*
-        - `Min Range` - minimum range of the sensor (if not avaiable, the range is different for each laser in `Laser Array`)
-        - `Max Range` - maximum range of the sensor (if not avaiable, the range is different for each laser in `Laser Array`)
-        - `High Resolution Mode Enabled` - whether to activate high resolution mode (available for `Hesai Pandar 128E4X` LiDAR model)
+        - Uniform range LiDARs
+            - `Min Range` - minimum range of the sensor
+            - `Max Range` - maximum range of the sensor
+        - Non-uniform range LiDARs
+            - `Range Modification Tooltip` - empty object to inform how to modify range via Tooltip
 
 #### Output Data
 `LidarSensor` provides public methods to extend this pipeline with additional `RGL` nodes.


### PR DESCRIPTION
This PR:
- Adds an empty element to the non-uniform range LiDARs to inform how to modify their range
- Separates high resolution mode of Hesai Pandar128E4X as a new preset to handle lasers modification
  - To implement this, we had to move the high resolution mode to a separate prefab, because the previous implementation always used Laser definitions straight from the code-based specification, so the range changes in the GUI would not be taken into account

| Uniform range LiDARs (e.g. VLP16) | Non-uniform LiDARs (e.g. Pandar128E4X) |
|---|---|
| ![rangeSettings](https://github.com/user-attachments/assets/6bbaf367-a5e9-48c8-9f0c-d9c1cf54ebdf) | ![rangeTooltip](https://github.com/user-attachments/assets/633719bc-6536-4153-a123-52ecf8da1c3a) |



