### PR TITLE
Fix Camera Sensor Feature Manager to Handle URP

### DIFF
--- a/Assets/AWSIM/Scripts/Editor/Sensors/CameraSensorFeatureManagerEditor.cs
+++ b/Assets/AWSIM/Scripts/Editor/Sensors/CameraSensorFeatureManagerEditor.cs
@@ -10,6 +10,7 @@ namespace AWSIM
     public class CameraSensorFeatureManagerEditor : Editor
     {
         private bool debugMode = false;
+        private bool prefabSettings = false;
 
         private SerializedProperty hueProperty;
         private SerializedProperty saturationProperty;
@@ -22,7 +23,9 @@ namespace AWSIM
         private SerializedProperty bloomEffectProperty;
         private SerializedProperty chromaticAberrationProperty;
         private SerializedProperty depthOfFieldProperty;
+        private SerializedProperty motionBlurProperty;
 
+        private SerializedProperty targetRendererProperty;
 
         private void OnEnable() 
         {
@@ -37,6 +40,9 @@ namespace AWSIM
             bloomEffectProperty = serializedObject.FindProperty("bloomEffect");
             chromaticAberrationProperty = serializedObject.FindProperty("chromaticAberration");
             depthOfFieldProperty = serializedObject.FindProperty("depthOfField");
+            motionBlurProperty = serializedObject.FindProperty("motionBlur");
+
+            targetRendererProperty = serializedObject.FindProperty("prefabTargetRenderer");
         }
 
         public override void OnInspectorGUI()
@@ -53,6 +59,16 @@ namespace AWSIM
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("profile"), true);
             }
         
+            // ------    Prefab Settings    ------- //
+            prefabSettings = GUILayout.Toggle(prefabSettings, new GUIContent("Show Prefab Settings", "Section with prefab settings"), "Button");
+            
+            if(prefabSettings)
+            {
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("prefabTargetRenderer"), true);
+            }
+
+            EditorGUILayout.Space(10f);
+
             // ------    Image Adjustment    ------- //
             EditorGUILayout.PropertyField(serializedObject.FindProperty("hue"), true);
             if(hueProperty.boolValue)
@@ -84,13 +100,17 @@ namespace AWSIM
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("sharpnessValue"), true);
             }
 
-            // ------    Exposure Settings    ------- //
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("exposureMode"), true);   
-            if(exposureModeProperty.enumValueIndex != 0)
+            // Show exposure settings only if the prefab is intended for HDRP. 
+            if(targetRendererProperty.enumValueIndex == 0)
             {
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("ISO"), true);
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("shutterSpeed"), true);
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("aperture"), true);
+                // ------    Exposure Settings    ------- //
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("exposureMode"), true);   
+                if(exposureModeProperty.enumValueIndex != 0)
+                {
+                    EditorGUILayout.PropertyField(serializedObject.FindProperty("ISO"), true);
+                    EditorGUILayout.PropertyField(serializedObject.FindProperty("shutterSpeed"), true);
+                    EditorGUILayout.PropertyField(serializedObject.FindProperty("aperture"), true);
+                }
             }
 
             // ------   Distortion Correction    ------- //
@@ -113,10 +133,23 @@ namespace AWSIM
             if(depthOfFieldProperty.boolValue)
             {
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("focusDistance"), true);
+            
+                // Show additional parameters only if the prefab is intended for URP. 
+                if(targetRendererProperty.enumValueIndex == 1)
+                {
+                    EditorGUILayout.PropertyField(serializedObject.FindProperty("aperture"), true);
+                }
             }
 
             EditorGUILayout.PropertyField(serializedObject.FindProperty("motionBlur"), true);
-
+            if(motionBlurProperty.boolValue)
+            {
+                // Show additional parameters only if the prefab is intended for URP. 
+                if(targetRendererProperty.enumValueIndex == 1)
+                {
+                    EditorGUILayout.PropertyField(serializedObject.FindProperty("shutterSpeed"), true);
+                }
+            }
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/AWSIM/Scripts/Sensors/Camera/CameraSensorFeatureManager.cs
+++ b/Assets/AWSIM/Scripts/Sensors/Camera/CameraSensorFeatureManager.cs
@@ -26,6 +26,12 @@ namespace AWSIM
             MANUAL = 1,
         }
 
+        private enum RenderingType
+        {
+            HDRP = 0,
+            URP = 1
+        }
+
         #region [Components]
 
         [Header("Components")]
@@ -33,6 +39,14 @@ namespace AWSIM
         [SerializeField] private CameraSensor cameraSensor = default;
         [SerializeField] private Volume volume = default;
         [SerializeField] private VolumeProfile profile = null;
+
+        #endregion
+
+        #region [Settings]
+
+        [Header("Prefab Settings")]
+        [Tooltip("The rendering pipeline for which the prefab is intended to be used.")]
+        [SerializeField] private RenderingType prefabTargetRenderer = RenderingType.HDRP;
 
         #endregion
 
@@ -317,6 +331,12 @@ namespace AWSIM
                 depthOfFieldComponent.active = depthOfField;
                 depthOfFieldComponent.focusDistance.overrideState = depthOfField;
                 depthOfFieldComponent.focusDistance.value = focusDistance;
+
+#if USE_URP
+                depthOfFieldComponent.aperture.overrideState = depthOfField;
+                depthOfFieldComponent.aperture.value = aperture;
+#endif
+
             }
         }
 
@@ -328,7 +348,7 @@ namespace AWSIM
                 motionBlurComponent.intensity.overrideState = motionBlur;
 
 #if USE_URP
-                motionBlurComponent.intensity.value = 1f;
+                motionBlurComponent.intensity.value = (2f / shutterSpeed) / Time.fixedDeltaTime;
 #else
                 float shutterSpeed = camera.GetComponent<HDAdditionalCameraData>().physicalParameters.shutterSpeed;
                 motionBlurComponent.intensity.value = 2f * shutterSpeed / Time.fixedDeltaTime;

--- a/Assets/AWSIM/Scripts/Sensors/Camera/CameraSensorFeatureManager.cs
+++ b/Assets/AWSIM/Scripts/Sensors/Camera/CameraSensorFeatureManager.cs
@@ -1,6 +1,11 @@
 using UnityEngine;
 using UnityEngine.Rendering;
+
+#if USE_URP
+using UnityEngine.Rendering.Universal;
+#else
 using UnityEngine.Rendering.HighDefinition;
+#endif
 
 namespace AWSIM
 {
@@ -115,7 +120,11 @@ namespace AWSIM
         #region [Effects Component]
 
         private ColorAdjustments colorAdjustmentsComponent = default;
+
+#if !USE_URP // Exposure effect is only supported by HDRP
         private Exposure exposureComponent = default;
+#endif
+
         private Bloom bloomComponent = default;
         private ChromaticAberration chromaticAberrationComponent = default;
         private DepthOfField depthOfFieldComponent = default;
@@ -132,10 +141,12 @@ namespace AWSIM
                 Debug.LogWarning("The required Color Adjustment property is not found in camera volume profile.");
             }
 
+#if !USE_URP // Exposure effect is only supported by HDRP
             if(!profile.TryGet<Exposure>(out exposureComponent))
             {
                 Debug.LogWarning("The required Exposure property is not found in camera volume profile.");
             }
+#endif
 
             if(!profile.TryGet<Bloom>(out bloomComponent))
             {
@@ -172,6 +183,7 @@ namespace AWSIM
 
             camera.gameObject.SetActive(cameraObjectActive);
 
+#if !USE_URP
             // exposure mode
             if(exposureComponent != null)
             {
@@ -184,9 +196,12 @@ namespace AWSIM
                     exposureComponent.mode = new ExposureModeParameter(ExposureMode.UsePhysicalCamera, true);
                 }
             }
+#endif
 
+#if !USE_URP
             // exposure settings
             ApplyExposureSettings();
+#endif
 
             // image adjustments
             ApplyImageAdjustments();
@@ -210,12 +225,14 @@ namespace AWSIM
             ApplyMotionBlur();
         }
 
+#if !USE_URP
         private void ApplyExposureSettings()
         {
             camera.GetComponent<HDAdditionalCameraData>().physicalParameters.iso = ISO;
             camera.GetComponent<HDAdditionalCameraData>().physicalParameters.shutterSpeed = 1f/shutterSpeed;
             camera.GetComponent<HDAdditionalCameraData>().physicalParameters.aperture = aperture;
         }
+#endif
     
         private void ApplyImageAdjustments()
         {
@@ -310,8 +327,12 @@ namespace AWSIM
                 motionBlurComponent.active = motionBlur;
                 motionBlurComponent.intensity.overrideState = motionBlur;
 
+#if USE_URP
+                motionBlurComponent.intensity.value = 1f;
+#else
                 float shutterSpeed = camera.GetComponent<HDAdditionalCameraData>().physicalParameters.shutterSpeed;
                 motionBlurComponent.intensity.value = 2f * shutterSpeed / Time.fixedDeltaTime;
+#endif
             }
         }
     }


### PR DESCRIPTION
Issue:
At the moment, The `Camera Sensor Feature Manager` script and its editor extension only support the HDRP. After switch to URP, the errors with missing library show up.

Solution:

This PR provides:

- changes to `CameraSensorFeatureManager` script, to handle both HDRP and URP. Script Define Symbol 'USE_URP' is used to determine whether the script is used by HDRP or URP.
- Additionally, the `CameraSensorFeatureManagerEditor` was modified as well, to handle the difference between HDRP and URP. 