### PR TITLE
Do expensive publishing operation in a seperate thread to resolve bottleneck

### DIFF
--- a/Assets/AWSIM/Scripts/Sensors/Camera/CameraRos2Publisher.cs
+++ b/Assets/AWSIM/Scripts/Sensors/Camera/CameraRos2Publisher.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using ROS2;
+using System.Threading.Tasks;
 
 namespace AWSIM
 {
@@ -84,9 +85,12 @@ namespace AWSIM
             imageMsg.Header.Stamp = timeMsg;
             cameraInfoMsg.Header.Stamp = timeMsg;
 
+
             // Publish to ROS2
-            imagePublisher.Publish(imageMsg);
-            cameraInfoPublisher.Publish(cameraInfoMsg);
+            var taskBoth = Task.Run(() => {
+                imagePublisher.Publish(imageMsg);
+                cameraInfoPublisher.Publish(cameraInfoMsg);
+            });
         }
 
         private void UpdateImageMsg(CameraSensor.OutputData data)


### PR DESCRIPTION
The publishing of images in the main thread is creating a bottleneck for the simulation, decreasing the FPS significantly when the simulator and Autoware are running on separate computers. Publishing in a separate thread fixes the issue.