### PR TITLE
Add SmokeGeneator to AWSIM2.0

### DIFF
--- a/Assets/Awsim/Prefabs/Entity/Environments/SmokeGenerator.prefab
+++ b/Assets/Awsim/Prefabs/Entity/Environments/SmokeGenerator.prefab
@@ -1,0 +1,102 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8471088462913240511
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 600039482839558331}
+  - component: {fileID: 1012453744923399850}
+  - component: {fileID: 1102325520381970394}
+  m_Layer: 0
+  m_Name: SmokeGenerator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &600039482839558331
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8471088462913240511}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 222.8123, y: 1.17, z: -277.17877}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1012453744923399850
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8471088462913240511}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &1102325520381970394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8471088462913240511}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 69b61783e53e4b6dba39cbd658104bf5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _maxParticle: 250
+  _particleRangeRadius: 0.5
+  _particleSize: 0.07
+  _averageLifetime: 7.5
+  _variationLifetime: 2.5
+  _physics:
+    initialPlaneVelocity: 0.4
+    initialVerticalVelocity: -0.1
+    planeAcceleration: -0.04
+    verticalAcceleration: 0.04

--- a/Assets/Awsim/Prefabs/Entity/Environments/SmokeGenerator.prefab.meta
+++ b/Assets/Awsim/Prefabs/Entity/Environments/SmokeGenerator.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 25fe78c23184dff3ab99b89238d34e98
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator.meta
+++ b/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1c1e8d77264b88baab908fb7cb547188
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeGenerator.cs
+++ b/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeGenerator.cs
@@ -1,0 +1,96 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Awsim.Entity
+{ 
+    [RequireComponent(typeof (MeshRenderer))]
+
+    /// <summary>
+    /// Smoke Generator class.
+    /// </summary>
+    [System.Serializable]
+    public class SmokeGenerator : MonoBehaviour
+    {
+        [Tooltip("Specifies the maximum number of smoke particles in a scene.")]
+        [SerializeField]
+        [Range(1, 1000)]
+        private int _maxParticle = 250;
+        [Tooltip("Specifies the radius of a circular region where particles are randomly generated in [m].")]
+        [SerializeField]
+        [Range(0.01f, 3.0f)]
+        private float _particleRangeRadius = 2.0f;
+        [Tooltip("Specifies the size of a smoke particle in [m].")]
+        [SerializeField]
+        [Range(0.005f, 0.1f)]
+        private float _particleSize = 0.07f;
+        [Tooltip("Specifies the average lifetime of a particle in [s].")]
+        [SerializeField]
+        [Range(5.0f, 15.0f)]
+        private float _averageLifetime = 7.5f;
+        [Tooltip("Specifies the variation range of lifetime of a particle in [s].")]
+        [SerializeField]
+        [Range(0.0f, 5.0f)]
+        private float _variationLifetime = 2.5f;
+
+        [SerializeField]
+        private SmokeParticlePhysics _physics;
+
+        public void Initialize()
+        {
+            for (int i = 0; i < _maxParticle; i++)
+            {
+                this.CreateSmokeParticle();
+            }
+            Debug.Log("SmokeGenerator initialized with material: " + GetComponent<MeshRenderer>().material.name);
+        }
+
+        public void OnUpdate()
+        {
+            if (this.transform.childCount < _maxParticle)
+            {
+                this.CreateSmokeParticle();
+            }
+
+            foreach (Transform child in transform)
+            {
+                var smoke = child.GetComponent<SmokeParticle>();
+                if (smoke != null)
+                {
+                    smoke.OnUpdate();
+                }
+            }
+        }
+        
+        private void CreateSmokeParticle()
+        {
+            float angleRad = Random.Range(0.0f, (float)System.Math.PI * 2.0f);
+            float radius = Random.Range(0.0f, _particleRangeRadius);
+            SmokeParticle.Create(gameObject, _particleSize, radius, angleRad);
+        }
+
+        /// <summary>
+        /// Returns particle size.
+        /// </summary>
+        public float GetParticleSize()
+        {
+            return this._particleSize;
+        }
+
+        /// <summary>
+        /// Returns initial velocity and acceleration of particle.
+        /// </summary>
+        public float[] GetVelAcc()
+        {
+            return new float[4] {this._physics.initialPlaneVelocity, this._physics.initialVerticalVelocity, this._physics.planeAcceleration, this._physics.verticalAcceleration};
+        }
+
+        /// <summary>
+        /// Returns lifetime of particle.
+        /// </summary>
+        public double GetLifetime()
+        {
+            return (double)(_averageLifetime + Random.Range(-_variationLifetime, _variationLifetime));
+        }
+    }
+}

--- a/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeGenerator.cs.meta
+++ b/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 69b61783e53e4b6dba39cbd658104bf5

--- a/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeParticle.cs
+++ b/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeParticle.cs
@@ -1,0 +1,135 @@
+using UnityEngine;
+using Awsim.Entity;
+
+namespace Awsim.Entity
+{ 
+	[RequireComponent(typeof(MeshFilter))]
+	[RequireComponent(typeof (MeshRenderer))]
+
+	/// <summary>
+	/// Smoke Particle class.
+	/// </summary>
+	public class SmokeParticle : MonoBehaviour
+	{
+		private SmokeGenerator _parentComp;
+		private double _lifeTime;
+		private Vector3 _velocity = new Vector3(0.0f, -0.05f, 0.0f);
+		private Vector3 _acceleration = new Vector3(0.0f, 0.05f, 0.0f);
+		
+        public void Initialize()
+		{
+		    this.CreateCube();
+		    this._lifeTime = _parentComp.GetLifetime();
+
+		    Material mat = this._parentComp.GetComponent<MeshRenderer>().material;
+		    MeshRenderer rend = GetComponent<MeshRenderer>();
+		    if (rend != null)
+		        rend.material = mat;
+		}
+
+		public void OnUpdate()
+		{
+		    this._velocity += this._acceleration * Time.deltaTime;
+			Vector3 displacement = this._velocity * Time.deltaTime;
+		    this.transform.position += displacement;
+
+		    this._lifeTime -= Time.deltaTime;
+		    if (_lifeTime <= 0.0)
+		        Destroy(gameObject);
+		}
+
+		private void CreateCube()
+		{
+			float size = this._parentComp.GetParticleSize();
+
+			Vector3[] vertices = {
+				new Vector3 (0, 0, 0),
+				new Vector3 (size, 0, 0),
+				new Vector3 (size, size, 0),
+				new Vector3 (0, size, 0),
+				new Vector3 (0, size, size),
+				new Vector3 (size, size, size),
+				new Vector3 (size, 0, size),
+				new Vector3 (0, 0, size),
+			};
+
+			int[] triangles = {
+				0, 2, 1,
+				0, 3, 2,
+				2, 3, 4,
+				2, 4, 5,
+				1, 2, 5,
+				1, 5, 6,
+				0, 7, 4,
+				0, 4, 3,
+				5, 4, 7,
+				5, 7, 6,
+				0, 6, 7,
+				0, 1, 6
+			};
+
+			Mesh mesh = GetComponent<MeshFilter>().mesh;
+			mesh.Clear();
+			mesh.vertices = vertices;
+			mesh.triangles = triangles;
+			mesh.Optimize();
+			mesh.RecalculateNormals();
+		}
+
+		/// <summary>
+		/// Gets and sets the SmokeGenerator component of the parent GameObject.
+		/// </summary>
+		/// <param name="gameObject">Parent GameObject of the Smoke Particle.</param>
+		public void SetParentComp(GameObject gameObject)
+		{
+			this._parentComp = gameObject.GetComponentInParent<SmokeGenerator>();
+		}
+
+		/// <summary>
+		/// Sets the initial velocity and acceleration of Smoke Particle.
+		/// </summary>
+		/// <param name="angleRad">Angular location of Smoke Particle in radians.</param>
+		public void SetVelAcc(float angleRad)
+		{
+			float[] velAcc = this._parentComp.GetVelAcc();
+			float velPlane = velAcc[0];
+			float velY = velAcc[1];
+			float accPlane = velAcc[2];
+			float accY = velAcc[3];
+
+			float velX = velPlane * (float)System.Math.Cos(angleRad);
+			float velZ = velPlane * (float)System.Math.Sin(angleRad);
+			this._velocity = new Vector3(velX, velY, velZ);
+
+			float accX = accPlane * (float)System.Math.Cos(angleRad);
+			float accZ = accPlane * (float)System.Math.Sin(angleRad);
+			this._acceleration = new Vector3(accX, accY, accZ);
+		}
+
+		/// <summary>
+		/// Creates a new Smoke Particle GameObject of specified properties.
+		/// </summary>
+		/// <param name="gameObject">Parent GameObject of the Smoke Particle.</param>
+		/// <param name="particle_size">Edge length of the Smoke Particle in [m].</param>
+		/// <param name="radius">Radius of a circle which defines the region where the Smoke Particle is generated in.</param>
+		/// <param name="angleRad">Angular location of the Smoke Particle to be generated at.</param>
+		public static void Create(GameObject gameObject, float particle_size, float radius, float angleRad)
+		{
+			GameObject particle = new GameObject("Particle");
+			particle.transform.parent = gameObject.transform;
+
+			float x = radius * (float)System.Math.Cos(angleRad);
+			float z = radius * (float)System.Math.Sin(angleRad);
+			float y = Random.Range(0.0f, 1.5f);
+			particle.transform.position = gameObject.transform.position + new Vector3(x, y, z);
+
+			particle.AddComponent(typeof(MeshFilter));
+			particle.AddComponent(typeof(MeshRenderer));
+
+			var smoke = particle.AddComponent<SmokeParticle>();
+			smoke.SetParentComp(gameObject);
+			smoke.SetVelAcc(angleRad);
+			smoke.Initialize();
+		}
+	}
+}

--- a/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeParticle.cs.meta
+++ b/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeParticle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e3cfa2ce6fc55fd98a1a9541f823e1be

--- a/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeParticlePhysics.cs
+++ b/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeParticlePhysics.cs
@@ -1,0 +1,26 @@
+using System;
+using UnityEngine;
+
+namespace Awsim.Entity
+{
+    /// <summary>
+    /// Struct for storing Smoke Particle class-related parameters.
+    /// </summary>
+    [Serializable]
+    public struct SmokeParticlePhysics
+    {
+        [Tooltip("Specifies the initial velocity of a smoke particle in the x-z plane in [m/s].")]
+        [Range(0.0f, 0.5f)]
+        public float initialPlaneVelocity;
+        [Tooltip("Specifies the vertical velocity of a smoke particle in [m/s].")]
+        [Range(-0.5f, 3.0f)]
+        public float initialVerticalVelocity;
+
+        [Tooltip("Specifies the acceleration of a smoke particle in the x-z plane in [m/s^2].")]
+        [Range(-0.1f, 0.1f)]
+        public float planeAcceleration;
+        [Tooltip("Specifies the vertical acceleration of a smoke particle in [m/s^2].")]
+        [Range(-0.1f, 0.1f)]
+        public float verticalAcceleration;
+    }
+}

--- a/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeParticlePhysics.cs.meta
+++ b/Assets/Awsim/Scripts/Entity/Environments/SmokeGenerator/SmokeParticlePhysics.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ed8ee6059cc1b4769a5a6ceb4727654a


### PR DESCRIPTION
- Removed usage of Unity's `Start()` and `Update()` methods in `SmokeGenerator` and `SmokeParticle`.
- Introduced `Initialize()` and `OnUpdate()` methods, which are now called explicitly from the scene.