### PR TITLE
fix: `LaneletLoader` apply v2.0.0

### DIFF
--- a/Assets/Awsim/Scripts/Editor/Usecase/TrafficSimulation/Environments/LaneletLoader/LaneletLoader.cs
+++ b/Assets/Awsim/Scripts/Editor/Usecase/TrafficSimulation/Environments/LaneletLoader/LaneletLoader.cs
@@ -165,6 +165,7 @@ namespace Awsim.Usecase.TrafficSimulation
                     : TrafficLane.TurnDirectionType.Straight;
                 var trafficLane = TrafficLane.Create(waypoints, turnDirection, speedLimitMps);
                 trafficLane.transform.parent = trafficLaneHolder.transform;
+                trafficLane.name = "TrafficLane." + (int)lanelet.ID;
                 trafficLanes.Add(lanelet.ID, trafficLane);
             }
         }

--- a/Assets/Awsim/Scripts/Editor/Usecase/TrafficSimulation/Environments/LaneletLoader/LaneletLoaderWindow.cs
+++ b/Assets/Awsim/Scripts/Editor/Usecase/TrafficSimulation/Environments/LaneletLoader/LaneletLoaderWindow.cs
@@ -22,7 +22,7 @@ namespace Awsim.Usecase.TrafficSimulation
     {
         [SerializeField] OsmDataContainer _osm;
         [SerializeField] LaneletLoader.WaypointSettings _waypointSettings = LaneletLoader.WaypointSettings.Default();
-        [SerializeField] GameObject _gameObjectHolder;
+        [SerializeField] GameObject _rootObject;
         SerializedObject _serializedObject;
 
         [MenuItem("AWSIM/Usecase/TrafficSimulation/Load Lanelet")]
@@ -48,8 +48,8 @@ namespace Awsim.Usecase.TrafficSimulation
             var settingsProperty = _serializedObject.FindProperty("_waypointSettings");
             settingsProperty.isExpanded = true;
             EditorGUILayout.PropertyField(settingsProperty, true);
-            var gameObjectHolder = _serializedObject.FindProperty("_gameObjectHolder");
-            EditorGUILayout.PropertyField(gameObjectHolder, true);
+            var rootObject = _serializedObject.FindProperty("_rootObject");
+            EditorGUILayout.PropertyField(rootObject, true);
 
             _serializedObject.ApplyModifiedProperties();
 
@@ -58,7 +58,7 @@ namespace Awsim.Usecase.TrafficSimulation
                 var referencePoint = MgrsPosition.Instance.Mgrs.Position;
                 var loader = new LaneletLoader();
                 loader.SetWaypointSettings(_waypointSettings);
-                loader.Load(_osm.Data, referencePoint, _gameObjectHolder);        // TODO:
+                loader.Load(_osm.Data, referencePoint, _rootObject);        // TODO:
             }
         }
     }

--- a/Assets/Awsim/Scripts/Editor/Usecase/TrafficSimulation/Environments/LaneletLoader/LaneletLoaderWindow.cs
+++ b/Assets/Awsim/Scripts/Editor/Usecase/TrafficSimulation/Environments/LaneletLoader/LaneletLoaderWindow.cs
@@ -22,6 +22,7 @@ namespace Awsim.Usecase.TrafficSimulation
     {
         [SerializeField] OsmDataContainer _osm;
         [SerializeField] LaneletLoader.WaypointSettings _waypointSettings = LaneletLoader.WaypointSettings.Default();
+        [SerializeField] GameObject _gameObjectHolder;
         SerializedObject _serializedObject;
 
         [MenuItem("AWSIM/Usecase/TrafficSimulation/Load Lanelet")]
@@ -47,6 +48,8 @@ namespace Awsim.Usecase.TrafficSimulation
             var settingsProperty = _serializedObject.FindProperty("_waypointSettings");
             settingsProperty.isExpanded = true;
             EditorGUILayout.PropertyField(settingsProperty, true);
+            var gameObjectHolder = _serializedObject.FindProperty("_gameObjectHolder");
+            EditorGUILayout.PropertyField(gameObjectHolder, true);
 
             _serializedObject.ApplyModifiedProperties();
 
@@ -55,7 +58,7 @@ namespace Awsim.Usecase.TrafficSimulation
                 var referencePoint = MgrsPosition.Instance.Mgrs.Position;
                 var loader = new LaneletLoader();
                 loader.SetWaypointSettings(_waypointSettings);
-                loader.Load(_osm.Data, referencePoint, null);        // TODO:
+                loader.Load(_osm.Data, referencePoint, _gameObjectHolder);        // TODO:
             }
         }
     }


### PR DESCRIPTION
## Checklist before requesting a review
- [x] Follow [coding standards](https://tier4.github.io/AWSIM/DeveloperGuide/CodingStandards/).
- [x] Follow [AWSIM architecture](https://tier4.github.io/AWSIM/DeveloperGuide/Architecture/).
- [x] No unnecessary comments or `Debug.Log()` remain.
- [x] The latest `main` branch has been merged into the work branch.
- [x] The expected behavior is achieved after implementation. Furthermore, existing functions are not affected.

## Implementation
1. Add field of `Root Game Object` to input hierarchy of generated `TrafficLanes` and `StopLine` ([#4e321a9](https://github.com/tier4/AWSIM/pull/406/commits/4e321a9f22f50874234ad282c68387889b13d8be), [#3beead9](https://github.com/tier4/AWSIM/pull/406/commits/3beead97985404e9b148e1f2a6be48c7ce601b92))
2. Change implementation to give unique name to generated `TrafficLane` ([#3ad8d85](https://github.com/tier4/AWSIM/pull/406/commits/3ad8d859be0c55dbbfcc7484152e89cb314d2122))
  a. To avoid error below:
```
VerifyIntegrationEnvironmentElements error: Found repeated child name in the 'TrafficLanes' object: TrafficLane
UnityEngine.Debug:LogError (object)
Awsim.Usecase.TrafficSimulation.TrafficSimulator:verifyIntegrationEnvironmentElements () (at Assets/Awsim/Scripts/Usecase/TrafficSimulation/TrafficSimulator.cs:272)
Awsim.Usecase.TrafficSimulation.TrafficSimulator:Initialize () (at Assets/Awsim/Scripts/Usecase/TrafficSimulation/TrafficSimulator.cs:104)
Awsim.Scene.AutowareSimulationDemo.AutowareSimulationDemo:Start () (at Assets/Awsim/Scenes/AutowareSimulationDemo/AutowareSimulationDemo.cs:119)
```

## Behavior test
- use Lanelet loader to [shishinjuku map](https://tier4.github.io/AWSIM/GettingStarted/QuickStartDemo/#4-run-awsim-and-autoware)
- modify some lane (same as existing scene)
- no error detected
<img width="2490" height="1573" alt="image" src="https://github.com/user-attachments/assets/ad296317-e631-4570-a341-11cfbe68d52a" />
