### PR TITLE
docs(readme): announce repository transfer to Autoware Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> AWSIM has been transferred from [TIER IV](https://github.com/tier4) to [Autoware Foundation](https://github.com/autowarefoundation/) GitHub Organization at 2026-05-07.
+
 > [!NOTE]
 > AWSIM won the Grand Prize in the Innovation Award category of the Industry at the 17th Unity Awards. Click [here](https://unity.com/blog/17th-unity-awards-wrap-up-2025-winners-revealed) for more details.
 


### PR DESCRIPTION
- Add a prominent `[!IMPORTANT]` callout to `README.md` announcing that AWSIM has been transferred from the TIER IV GitHub organization to the Autoware Foundation GitHub organization on 2026-05-07.

## Why
The repository has moved organizations. Visitors landing on the repo should immediately see the new home so links, forks, and references can be updated.

---

## Test plan

- [ ] Open [README.md](https://github.com/autowarefoundation/AWSIM/blob/1d512496dd600845a3acdb0de47d684922c70d9a/README.md) on the PR's "Files changed" tab and confirm the new `[!IMPORTANT]` admonition renders above the existing `[!NOTE]` Unity Awards block.
- [ ] Confirm the two embedded links resolve:
  - https://github.com/tier4
  - https://github.com/autowarefoundation/
- [ ] Verify the date `2026-05-07` is correct.