### PR TITLE
chore(CODEOWNERS): update default code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mackierx111
+* @xmfcx @mitsudome-r


### PR DESCRIPTION
- Replace `@mackierx111` with @xmfcx and @mitsudome-r as the default owners in [`.github/CODEOWNERS`](https://github.com/autowarefoundation/AWSIM/blob/1d512496dd600845a3acdb0de47d684922c70d9a/.github/CODEOWNERS).

## Why
Hands maintainership of the repository to the current active maintainers so that PR review requests are routed to people who can act on them.

---

## Test plan

- [ ] After merge, open a test PR and confirm `@xmfcx` and `@mitsudome-r` are auto-requested as reviewers.
- [ ] Confirm `@mackierx111` is no longer auto-requested.