### PR TITLE
docs: warn that Shinjuku 3D models are non-commercial only

### DIFF
--- a/docs/DeveloperGuide/SetupUnityProject/index.md
+++ b/docs/DeveloperGuide/SetupUnityProject/index.md
@@ -132,6 +132,9 @@ AWSIM comes with a *standalone* flavor of [`Ros2ForUnity`](../../Components/ROS2
         
 ## 4. Import external packages
 
+!!! warning "Shinjuku 3D models — non-commercial use only"
+    The Shinjuku 3D models in `Shinjuku.unitypackage` are licensed under [CC BY-NC 4.0](../../License/index.md) and **must not be used for business or other commercial purposes**.
+
 1. Download `Shinjuku.unitypackage`
 
     [Download Shinjuku.unitypackage](https://github.com/tier4/AWSIM/releases/download/v2.0.0/Shinjuku.unitypackage){ .md-button }

--- a/docs/Downloads/index.md
+++ b/docs/Downloads/index.md
@@ -5,3 +5,6 @@
 |[AWSIM-Demo-OpenSCENARIO.zip](https://github.com/tier4/AWSIM/releases/download/v2.0.0/AWSIM-Demo-OpenSCENARIO.zip)|Demo simulation using OpenSCENARIO with AWSIM. Connect AWSIM, Autoware, and [Scenario Simulator v2.](https://github.com/tier4/scenario_simulator_v2). see also [here](../DeveloperGuide/Experimental/UsingOpenScenario/index.md).|
 |[Shinjuku.unitypackage](https://github.com/tier4/AWSIM/releases/download/v2.0.0/Shinjuku.unitypackage)|`.unitypackage` for Shinjuku to import into UnityEditor. see also [here](../DeveloperGuide/SetupUnityProject/index.md).|
 |[Shinjuku-Map.zip](https://github.com/tier4/AWSIM/releases/download/v2.0.0/Shinjuku-Map.zip)|Map files used in Autoware. `.osm` and `.pcd` files for Shinjuku.|.
+
+!!! warning "Shinjuku 3D models — non-commercial use only"
+    The Shinjuku 3D models (`Shinjuku.unitypackage` and the Shinjuku scene shipped in the demo builds) are licensed under [CC BY-NC 4.0](../License/index.md) and **must not be used for business or other commercial purposes**.


### PR DESCRIPTION
- Add a `!!! warning` admonition next to every Shinjuku asset reference in the docs, calling out that the 3D models are licensed under [CC BY-NC 4.0](https://github.com/autowarefoundation/AWSIM/blob/ae359ab63d6795926420745c1a321dc163d85f92/docs/License/index.md) and must not be used for business or other commercial purposes.
- Updated [docs/Downloads/index.md](https://github.com/autowarefoundation/AWSIM/blob/ae359ab63d6795926420745c1a321dc163d85f92/docs/Downloads/index.md) (under the Shinjuku rows) and [docs/DeveloperGuide/SetupUnityProject/index.md](https://github.com/autowarefoundation/AWSIM/blob/ae359ab63d6795926420745c1a321dc163d85f92/docs/DeveloperGuide/SetupUnityProject/index.md) (top of section 4, *Import external packages*).

## Why
The CC BY-NC restriction on the Shinjuku assets only lives in the License page today, so users who land directly on the download or setup pages can easily miss it. Surfacing the restriction at the point of download removes ambiguity for anyone evaluating AWSIM for commercial use.

---

## Test plan

- [x] Build the docs site locally and confirm both warnings render as styled admonitions:
  ```
  pip install mkdocs-material && mkdocs serve
  ```
- [x] Open `http://127.0.0.1:8000/Downloads/` — verify the warning appears below the Shinjuku table rows and the *CC BY-NC 4.0* link resolves to the License page.
- [x] Open `http://127.0.0.1:8000/DeveloperGuide/SetupUnityProject/` — verify the warning appears at the top of *4. Import external packages*, above the `Shinjuku.unitypackage` download button, and the license link resolves correctly.
- [x] No other docs pages, code, or build configuration changed (`git diff main..HEAD --stat` shows only the two `.md` files).